### PR TITLE
refactor(prp-plan): extract references/templates, trim SKILL.md to a lean spine

### DIFF
--- a/.claude/skills/prp-plan/SKILL.md
+++ b/.claude/skills/prp-plan/SKILL.md
@@ -131,49 +131,10 @@ So that <benefit/value>
 
 ## Phase 2: EXPLORE - Codebase Intelligence
 
-**CRITICAL: Launch two specialized agents in parallel using multiple Task tool calls in a single message.**
+**CRITICAL: Launch two specialized agents in parallel using multiple Task tool calls in a single message.** Read `references/agent-prompts.md` now (mandatory) — it is the exact prompt text for every subagent launch in Phases 2, 3, and 5.
 
-### Agent 1: `prp-core:codebase-explorer`
-
-Finds WHERE code lives and extracts implementation patterns.
-
-Use Task tool with `subagent_type="prp-core:codebase-explorer"`:
-
-```
-Find all code relevant to implementing: [feature description].
-
-LOCATE:
-1. Similar implementations - analogous features with file:line references
-2. Naming conventions - actual examples of function/class/file naming
-3. Error handling patterns - how errors are created, thrown, caught
-4. Logging patterns - logger usage, message formats
-5. Type definitions - relevant interfaces and types
-6. Test patterns - test file structure, assertion styles, test file locations
-7. Configuration - relevant config files and settings
-8. Dependencies - relevant libraries already in use
-
-Categorize findings by purpose (implementation, tests, config, types, docs).
-Return ACTUAL code snippets from codebase, not generic examples.
-```
-
-### Agent 2: `prp-core:codebase-analyst`
-
-Analyzes HOW integration points work and traces data flow.
-
-Use Task tool with `subagent_type="prp-core:codebase-analyst"`:
-
-```
-Analyze the implementation details relevant to: [feature description].
-
-TRACE:
-1. Entry points - where new code will connect to existing code
-2. Data flow - how data moves through related components
-3. State changes - side effects in related functions
-4. Contracts - interfaces and expectations between components
-5. Patterns in use - design patterns and architectural decisions
-
-Document what exists with precise file:line references. No suggestions or improvements.
-```
+- **Agent 1: `prp-core:codebase-explorer`** — finds WHERE code lives and extracts implementation patterns. Launch with the Phase 2 codebase-explorer prompt.
+- **Agent 2: `prp-core:codebase-analyst`** — analyzes HOW integration points work and traces data flow. Launch with the Phase 2 codebase-analyst prompt.
 
 ### Merge Agent Results
 
@@ -202,27 +163,7 @@ Combine findings from both agents into a unified discovery table:
 
 **ONLY AFTER Phase 2 is complete** - solutions must fit existing codebase patterns first.
 
-**Use Task tool with `subagent_type="prp-core:web-researcher"`:**
-
-```
-Research external documentation relevant to implementing: [feature description].
-
-FIND:
-1. Official documentation for involved libraries (match versions from package.json: [list relevant deps and versions])
-2. Known gotchas, breaking changes, deprecations for these versions
-3. Security considerations and best practices
-4. Performance optimization patterns
-
-VERSION CONSTRAINTS:
-- [library]: v{version} (from package.json)
-- [library]: v{version}
-
-Return findings with:
-- Direct links to specific doc sections (not just homepages)
-- Key insights that affect implementation
-- Gotchas with mitigation strategies
-- Any conflicts between docs and existing codebase patterns found in Phase 2
-```
+**Launch `prp-core:web-researcher`** with the Phase 3 web-researcher prompt from `references/agent-prompts.md`, filling in the feature description and the dependency versions found in Phase 2.
 
 **FORMAT the agent's findings into plan references:**
 
@@ -245,51 +186,7 @@ Return findings with:
 
 ## Phase 4: DESIGN - UX Transformation
 
-**CREATE ASCII diagrams showing user experience before and after:**
-
-```
-╔═══════════════════════════════════════════════════════════════════════════════╗
-║                              BEFORE STATE                                      ║
-╠═══════════════════════════════════════════════════════════════════════════════╣
-║                                                                               ║
-║   ┌─────────────┐         ┌─────────────┐         ┌─────────────┐            ║
-║   │   Screen/   │ ──────► │   Action    │ ──────► │   Result    │            ║
-║   │  Component  │         │   Current   │         │   Current   │            ║
-║   └─────────────┘         └─────────────┘         └─────────────┘            ║
-║                                                                               ║
-║   USER_FLOW: [describe current step-by-step experience]                       ║
-║   PAIN_POINT: [what's missing, broken, or inefficient]                        ║
-║   DATA_FLOW: [how data moves through the system currently]                    ║
-║                                                                               ║
-╚═══════════════════════════════════════════════════════════════════════════════╝
-
-╔═══════════════════════════════════════════════════════════════════════════════╗
-║                               AFTER STATE                                      ║
-╠═══════════════════════════════════════════════════════════════════════════════╣
-║                                                                               ║
-║   ┌─────────────┐         ┌─────────────┐         ┌─────────────┐            ║
-║   │   Screen/   │ ──────► │   Action    │ ──────► │   Result    │            ║
-║   │  Component  │         │    NEW      │         │    NEW      │            ║
-║   └─────────────┘         └─────────────┘         └─────────────┘            ║
-║                                   │                                           ║
-║                                   ▼                                           ║
-║                          ┌─────────────┐                                      ║
-║                          │ NEW_FEATURE │  ◄── [new capability added]          ║
-║                          └─────────────┘                                      ║
-║                                                                               ║
-║   USER_FLOW: [describe new step-by-step experience]                           ║
-║   VALUE_ADD: [what user gains from this change]                               ║
-║   DATA_FLOW: [how data moves through the system after]                        ║
-║                                                                               ║
-╚═══════════════════════════════════════════════════════════════════════════════╝
-```
-
-**DOCUMENT interaction changes:**
-
-| Location        | Before          | After       | User_Action | Impact        |
-| --------------- | --------------- | ----------- | ----------- | ------------- |
-| `/route`        | State A         | State B     | Click X     | Can now Y     |
-| `Component.tsx` | Missing feature | Has feature | Input Z     | Gets result W |
+**CREATE ASCII diagrams showing user experience before and after, then DOCUMENT interaction changes.** Read `templates/ux-diagram-format.md` now (mandatory) — it is the exact BEFORE/AFTER diagram shape and interaction-changes table to produce.
 
 **PHASE_4_CHECKPOINT:**
 
@@ -302,25 +199,7 @@ Return findings with:
 
 ## Phase 5: ARCHITECT - Strategic Design
 
-**For complex features with multiple integration points**, use `prp-core:codebase-analyst` to trace how existing architecture works at the integration points identified in Phase 2:
-
-Use Task tool with `subagent_type="prp-core:codebase-analyst"`:
-
-```
-Analyze the architecture around these integration points for: [feature description].
-
-INTEGRATION POINTS (from Phase 2):
-- [entry point 1 from explorer/analyst findings]
-- [entry point 2]
-
-ANALYZE:
-1. How data flows through each integration point
-2. What contracts exist between components
-3. What side effects occur at each stage
-4. What error handling patterns are in place
-
-Document what exists with precise file:line references. No suggestions.
-```
+**For complex features with multiple integration points**, use `prp-core:codebase-analyst` to trace how existing architecture works at the integration points identified in Phase 2 — launch with the Phase 5 architecture deep-dive prompt from `references/agent-prompts.md`.
 
 **Then ANALYZE deeply (use extended thinking if needed):**
 
@@ -363,7 +242,7 @@ NOT_BUILDING (explicit scope limits):
 
 Create directory if needed: `mkdir -p .claude/PRPs/plans`
 
-**PLAN_STRUCTURE**: Read `templates/plan-template.md` now (mandatory) — it is the exact plan document to fill and save. Keep every section heading; fill every `{placeholder}` with real, project-specific content (the template's task entries and snippets are illustrative examples from one TypeScript project, not content to keep).
+**PLAN_STRUCTURE**: Read `templates/plan-template.md` now (mandatory) — it is the exact plan document to fill and save. Keep every section heading; fill every `{placeholder}` with real, project-specific content (the template's remaining snippets and table entries are illustrative examples from one TypeScript project, not content to keep). Before writing the plan's Step-by-Step Tasks section, read `references/task-block-format.md` (mandatory) for the task-block field detail and worked examples; before filling its Validation Commands section, read `references/validation-commands.md` (mandatory) for the per-language commands to embed.
 
 </process>
 
@@ -378,51 +257,7 @@ Create directory if needed: `mkdir -p .claude/PRPs/plans`
 
 2. **Edit the PRD file** with these changes
 
-**REPORT_TO_USER** (display after creating plan):
-
-```markdown
-## Plan Created
-
-**File**: `.claude/PRPs/plans/{feature-name}.plan.md`
-
-{If from PRD:}
-**Source PRD**: `{prd-file-path}`
-**Phase**: #{number} - {phase name}
-**PRD Updated**: Status set to `in-progress`, plan linked
-
-{If parallel phases available:}
-**Parallel Opportunity**: Phase {X} can run concurrently in a separate worktree.
-To start: `git worktree add -b phase-{X} ../project-phase-{X} && cd ../project-phase-{X} && /prp-plan {prd-path}`
-
-**Summary**: {2-3 sentence feature overview}
-
-**Complexity**: {LOW/MEDIUM/HIGH} - {brief rationale}
-
-**Scope**:
-- {N} files to CREATE
-- {M} files to UPDATE
-- {K} total tasks
-
-**Key Patterns Discovered**:
-- {Pattern 1 from codebase-explorer/analyst with file:line}
-- {Pattern 2 from codebase-explorer/analyst with file:line}
-
-**External Research**:
-- {Key doc 1 with version}
-- {Key doc 2 with version}
-
-**UX Transformation**:
-- BEFORE: {one-line current state}
-- AFTER: {one-line new state}
-
-**Risks**:
-- {Primary risk}: {mitigation}
-
-**Confidence Score**: {1-10}/10 for one-pass implementation success
-- {Rationale for score}
-
-**Next Step**: To execute, run: `/prp-implement .claude/PRPs/plans/{feature-name}.plan.md`
-```
+**REPORT_TO_USER** (display after creating plan): Read `templates/report-format.md` now (mandatory) and display the "Plan Created" report in exactly that structure.
 
 </output>
 
@@ -478,5 +313,10 @@ To start: `git worktree add -b phase-{X} ../project-phase-{X} && cd ../project-p
 
 ## Resources
 
-- `templates/plan-template.md` — the plan document to fill and save (read in Phase 6)
+- `references/agent-prompts.md` — exact subagent prompts for Phases 2, 3, and 5 (mandatory read at Phase 2)
+- `templates/plan-template.md` — the plan document to fill and save (mandatory read in Phase 6)
+- `templates/ux-diagram-format.md` — the BEFORE/AFTER ASCII diagram shape and interaction-changes table (mandatory read in Phase 4)
+- `templates/report-format.md` — the "Plan Created" report displayed to the user (mandatory read in Output)
+- `references/task-block-format.md` — task-block field detail and worked examples (mandatory read in Phase 6, before writing Step-by-Step Tasks)
+- `references/validation-commands.md` — per-language validation command catalog (mandatory read in Phase 6, before filling Validation Commands)
 - `workflows/update-references.md` — the update-references mode (read only when Mode Select routes there)

--- a/.claude/skills/prp-plan/references/agent-prompts.md
+++ b/.claude/skills/prp-plan/references/agent-prompts.md
@@ -1,0 +1,85 @@
+# Subagent Prompts — Intelligence Gathering
+
+The exact prompt text for every subagent launch in Phases 2, 3, and 5. Fill the `[bracketed]` slots before sending; do not otherwise reword the prompts.
+
+## Phase 2 — codebase-explorer prompt
+
+Use Task tool with `subagent_type="prp-core:codebase-explorer"`:
+
+```
+Find all code relevant to implementing: [feature description].
+
+LOCATE:
+1. Similar implementations - analogous features with file:line references
+2. Naming conventions - actual examples of function/class/file naming
+3. Error handling patterns - how errors are created, thrown, caught
+4. Logging patterns - logger usage, message formats
+5. Type definitions - relevant interfaces and types
+6. Test patterns - test file structure, assertion styles, test file locations
+7. Configuration - relevant config files and settings
+8. Dependencies - relevant libraries already in use
+
+Categorize findings by purpose (implementation, tests, config, types, docs).
+Return ACTUAL code snippets from codebase, not generic examples.
+```
+
+## Phase 2 — codebase-analyst prompt
+
+Use Task tool with `subagent_type="prp-core:codebase-analyst"`:
+
+```
+Analyze the implementation details relevant to: [feature description].
+
+TRACE:
+1. Entry points - where new code will connect to existing code
+2. Data flow - how data moves through related components
+3. State changes - side effects in related functions
+4. Contracts - interfaces and expectations between components
+5. Patterns in use - design patterns and architectural decisions
+
+Document what exists with precise file:line references. No suggestions or improvements.
+```
+
+## Phase 3 — web-researcher prompt
+
+Use Task tool with `subagent_type="prp-core:web-researcher"`:
+
+```
+Research external documentation relevant to implementing: [feature description].
+
+FIND:
+1. Official documentation for involved libraries (match versions from package.json: [list relevant deps and versions])
+2. Known gotchas, breaking changes, deprecations for these versions
+3. Security considerations and best practices
+4. Performance optimization patterns
+
+VERSION CONSTRAINTS:
+- [library]: v{version} (from package.json)
+- [library]: v{version}
+
+Return findings with:
+- Direct links to specific doc sections (not just homepages)
+- Key insights that affect implementation
+- Gotchas with mitigation strategies
+- Any conflicts between docs and existing codebase patterns found in Phase 2
+```
+
+## Phase 5 — architecture deep-dive prompt
+
+Use Task tool with `subagent_type="prp-core:codebase-analyst"`:
+
+```
+Analyze the architecture around these integration points for: [feature description].
+
+INTEGRATION POINTS (from Phase 2):
+- [entry point 1 from explorer/analyst findings]
+- [entry point 2]
+
+ANALYZE:
+1. How data flows through each integration point
+2. What contracts exist between components
+3. What side effects occur at each stage
+4. What error handling patterns are in place
+
+Document what exists with precise file:line references. No suggestions.
+```

--- a/.claude/skills/prp-plan/references/task-block-format.md
+++ b/.claude/skills/prp-plan/references/task-block-format.md
@@ -1,0 +1,92 @@
+# Task Block Format — Field Detail & Worked Examples
+
+How to write the entries in the plan's "Step-by-Step Tasks" section. The section skeleton (status markers + the generic task block) lives in `templates/plan-template.md`; this file holds the field-by-field detail and a full worked example sequence.
+
+## Fields
+
+Each task is a bullet list under a `### `[ ]` Task N: {ACTION} `{file}`` header. Use the fields that apply:
+
+- **ACTION** — what to do to the file (CREATE / UPDATE / ADD ...)
+- **IMPLEMENT** — the specific content to implement (functions, columns, schemas)
+- **MIRROR** — `file:line` of the existing codebase pattern to copy exactly
+- **IMPORTS** — exact import statements the new code needs
+- **TYPES** — type definitions or inference patterns to use
+- **PATTERN** — the design pattern or structural rule to follow
+- **GOTCHA** — known issue to avoid, discovered in Phase 2/3 research
+- **VALIDATE** — executable command proving the task is done
+
+Every task MUST have at least MIRROR (or PATTERN) and VALIDATE. GOTCHA entries come from real research findings, not invented warnings.
+
+## Worked example sequence
+
+Illustrative examples from one TypeScript project — replace their content entirely with the target project's real files, patterns, and commands. Note the dependency order: schema → types → validation → errors → repository → service → public API → tests.
+
+### `[ ]` Task 1: UPDATE `src/core/database/schema.ts`
+
+- **ACTION**: ADD table definition to schema
+- **IMPLEMENT**: {specific columns, types, constraints}
+- **MIRROR**: `src/core/database/schema.ts:XX-YY` - follow existing table pattern
+- **IMPORTS**: `import { pgTable, text, timestamp } from "drizzle-orm/pg-core"`
+- **GOTCHA**: {known issue to avoid, e.g., "use uuid for id, not serial"}
+- **VALIDATE**: `npx tsc --noEmit` - types must compile
+
+### `[ ]` Task 2: CREATE `src/features/new/models.ts`
+
+- **ACTION**: CREATE type definitions file
+- **IMPLEMENT**: Re-export table, define inferred types
+- **MIRROR**: `src/features/projects/models.ts:1-10`
+- **IMPORTS**: `import { things } from "@/core/database/schema"`
+- **TYPES**: `type Thing = typeof things.$inferSelect`
+- **GOTCHA**: Use `$inferSelect` for read types, `$inferInsert` for write
+- **VALIDATE**: `npx tsc --noEmit`
+
+### `[ ]` Task 3: CREATE `src/features/new/schemas.ts`
+
+- **ACTION**: CREATE Zod validation schemas
+- **IMPLEMENT**: CreateThingSchema, UpdateThingSchema
+- **MIRROR**: `src/features/projects/schemas.ts:1-30`
+- **IMPORTS**: `import { z } from "zod/v4"` (note: zod/v4 not zod)
+- **GOTCHA**: z.record requires two args in v4
+- **VALIDATE**: `npx tsc --noEmit`
+
+### `[ ]` Task 4: CREATE `src/features/new/errors.ts`
+
+- **ACTION**: CREATE feature-specific error classes
+- **IMPLEMENT**: ThingNotFoundError, ThingAccessDeniedError
+- **MIRROR**: `src/features/projects/errors.ts:1-40`
+- **PATTERN**: Extend base Error, include code and statusCode
+- **VALIDATE**: `npx tsc --noEmit`
+
+### `[ ]` Task 5: CREATE `src/features/new/repository.ts`
+
+- **ACTION**: CREATE database operations
+- **IMPLEMENT**: findById, findByUserId, create, update, delete
+- **MIRROR**: `src/features/projects/repository.ts:1-60`
+- **IMPORTS**: `import { db } from "@/core/database/client"`
+- **GOTCHA**: Use `results[0]` pattern, not `.first()` - check noUncheckedIndexedAccess
+- **VALIDATE**: `npx tsc --noEmit`
+
+### `[ ]` Task 6: CREATE `src/features/new/service.ts`
+
+- **ACTION**: CREATE business logic layer
+- **IMPLEMENT**: createThing, getThing, updateThing, deleteThing
+- **MIRROR**: `src/features/projects/service.ts:1-80`
+- **PATTERN**: Use repository, add logging, throw custom errors
+- **IMPORTS**: `import { getLogger } from "@/core/logging"`
+- **VALIDATE**: `{type-check-cmd} && {lint-cmd}`
+
+### `[ ]` Task 7: CREATE `{source-dir}/features/new/index.ts`
+
+- **ACTION**: CREATE public API exports
+- **IMPLEMENT**: Export types, schemas, errors, service functions
+- **MIRROR**: `{source-dir}/features/{example}/index.ts:1-20`
+- **PATTERN**: Named exports only, hide repository (internal)
+- **VALIDATE**: `{type-check-cmd}`
+
+### `[ ]` Task 8: CREATE `{source-dir}/features/new/tests/service.test.ts`
+
+- **ACTION**: CREATE unit tests for service
+- **IMPLEMENT**: Test each service function, happy path + error cases
+- **MIRROR**: `{source-dir}/features/{example}/tests/service.test.ts:1-100`
+- **PATTERN**: Use project's test framework (jest, vitest, bun:test, pytest, etc.)
+- **VALIDATE**: `{test-cmd} {path-to-tests}`

--- a/.claude/skills/prp-plan/references/validation-commands.md
+++ b/.claude/skills/prp-plan/references/validation-commands.md
@@ -1,0 +1,19 @@
+# Validation Commands — Per-Language Catalog
+
+Concrete commands to substitute for the `{runner}` placeholders in the plan's "Validation Commands" section (see the level structure in `templates/plan-template.md`). Always replace placeholders with actual commands from the project's package.json/config — verify the script names exist before embedding them.
+
+## Level 1: STATIC_ANALYSIS
+
+Examples: `npm run lint`, `pnpm lint`, `ruff check . && mypy .`, `cargo clippy`
+
+## Level 2: UNIT_TESTS
+
+Examples: `npm test`, `pytest tests/`, `cargo test`, `go test ./...`
+
+## Level 3: FULL_SUITE
+
+Examples: `npm test && npm run build`, `cargo test && cargo build`
+
+## Levels 4-6
+
+Levels 4 (DATABASE_VALIDATION), 5 (BROWSER_VALIDATION), and 6 (MANUAL_VALIDATION) have no generic catalog — they are project-specific MCP tooling (e.g. Supabase MCP, Browser MCP) or step-by-step manual checks, as shaped in the plan template. Include them only where applicable.

--- a/.claude/skills/prp-plan/templates/plan-template.md
+++ b/.claude/skills/prp-plan/templates/plan-template.md
@@ -169,75 +169,16 @@ Execute in order. Each task is atomic and independently verifiable.
 
 **Status markers** — prefix EVERY task header with one; the build agent updates it inline as it works: `[ ]` idle · `[wip]` in progress · `[x]` complete · `[f]` failed. All tasks start `[ ]`. If a task cannot be made to pass, mark it `[f]`, record why in Agent Notes, and move on if the rest of the plan can still proceed.
 
-### `[ ]` Task 1: UPDATE `src/core/database/schema.ts`
+### `[ ]` Task {N}: {ACTION} `{path/to/file}`
 
-- **ACTION**: ADD table definition to schema
-- **IMPLEMENT**: {specific columns, types, constraints}
-- **MIRROR**: `src/core/database/schema.ts:XX-YY` - follow existing table pattern
-- **IMPORTS**: `import { pgTable, text, timestamp } from "drizzle-orm/pg-core"`
-- **GOTCHA**: {known issue to avoid, e.g., "use uuid for id, not serial"}
-- **VALIDATE**: `npx tsc --noEmit` - types must compile
+- **ACTION**: {what to do to this file - CREATE / UPDATE / ADD ...}
+- **IMPLEMENT**: {the specific content to implement}
+- **MIRROR**: `{path/to/analogous/file:lines}` - {existing pattern to copy exactly}
+- **IMPORTS**: {exact import statements the new code needs}
+- **GOTCHA**: {known issue to avoid, from research findings}
+- **VALIDATE**: `{executable command proving the task is done}`
 
-### `[ ]` Task 2: CREATE `src/features/new/models.ts`
-
-- **ACTION**: CREATE type definitions file
-- **IMPLEMENT**: Re-export table, define inferred types
-- **MIRROR**: `src/features/projects/models.ts:1-10`
-- **IMPORTS**: `import { things } from "@/core/database/schema"`
-- **TYPES**: `type Thing = typeof things.$inferSelect`
-- **GOTCHA**: Use `$inferSelect` for read types, `$inferInsert` for write
-- **VALIDATE**: `npx tsc --noEmit`
-
-### `[ ]` Task 3: CREATE `src/features/new/schemas.ts`
-
-- **ACTION**: CREATE Zod validation schemas
-- **IMPLEMENT**: CreateThingSchema, UpdateThingSchema
-- **MIRROR**: `src/features/projects/schemas.ts:1-30`
-- **IMPORTS**: `import { z } from "zod/v4"` (note: zod/v4 not zod)
-- **GOTCHA**: z.record requires two args in v4
-- **VALIDATE**: `npx tsc --noEmit`
-
-### `[ ]` Task 4: CREATE `src/features/new/errors.ts`
-
-- **ACTION**: CREATE feature-specific error classes
-- **IMPLEMENT**: ThingNotFoundError, ThingAccessDeniedError
-- **MIRROR**: `src/features/projects/errors.ts:1-40`
-- **PATTERN**: Extend base Error, include code and statusCode
-- **VALIDATE**: `npx tsc --noEmit`
-
-### `[ ]` Task 5: CREATE `src/features/new/repository.ts`
-
-- **ACTION**: CREATE database operations
-- **IMPLEMENT**: findById, findByUserId, create, update, delete
-- **MIRROR**: `src/features/projects/repository.ts:1-60`
-- **IMPORTS**: `import { db } from "@/core/database/client"`
-- **GOTCHA**: Use `results[0]` pattern, not `.first()` - check noUncheckedIndexedAccess
-- **VALIDATE**: `npx tsc --noEmit`
-
-### `[ ]` Task 6: CREATE `src/features/new/service.ts`
-
-- **ACTION**: CREATE business logic layer
-- **IMPLEMENT**: createThing, getThing, updateThing, deleteThing
-- **MIRROR**: `src/features/projects/service.ts:1-80`
-- **PATTERN**: Use repository, add logging, throw custom errors
-- **IMPORTS**: `import { getLogger } from "@/core/logging"`
-- **VALIDATE**: `{type-check-cmd} && {lint-cmd}`
-
-### `[ ]` Task 7: CREATE `{source-dir}/features/new/index.ts`
-
-- **ACTION**: CREATE public API exports
-- **IMPLEMENT**: Export types, schemas, errors, service functions
-- **MIRROR**: `{source-dir}/features/{example}/index.ts:1-20`
-- **PATTERN**: Named exports only, hide repository (internal)
-- **VALIDATE**: `{type-check-cmd}`
-
-### `[ ]` Task 8: CREATE `{source-dir}/features/new/tests/service.test.ts`
-
-- **ACTION**: CREATE unit tests for service
-- **IMPLEMENT**: Test each service function, happy path + error cases
-- **MIRROR**: `{source-dir}/features/{example}/tests/service.test.ts:1-100`
-- **PATTERN**: Use project's test framework (jest, vitest, bun:test, pytest, etc.)
-- **VALIDATE**: `{test-cmd} {path-to-tests}`
+{Repeat one block per task, in dependency order, numbered from 1.}
 
 ---
 
@@ -272,7 +213,6 @@ Execute in order. Each task is atomic and independently verifiable.
 
 ```bash
 {runner} run lint && {runner} run type-check
-# Examples: npm run lint, pnpm lint, ruff check . && mypy ., cargo clippy
 ```
 
 **EXPECT**: Exit 0, no errors or warnings
@@ -281,7 +221,6 @@ Execute in order. Each task is atomic and independently verifiable.
 
 ```bash
 {runner} test {path/to/feature/tests}
-# Examples: npm test, pytest tests/, cargo test, go test ./...
 ```
 
 **EXPECT**: All tests pass, coverage >= 80%
@@ -290,7 +229,6 @@ Execute in order. Each task is atomic and independently verifiable.
 
 ```bash
 {runner} test && {runner} run build
-# Examples: npm test && npm run build, cargo test && cargo build
 ```
 
 **EXPECT**: All tests pass, build succeeds

--- a/.claude/skills/prp-plan/templates/report-format.md
+++ b/.claude/skills/prp-plan/templates/report-format.md
@@ -1,0 +1,47 @@
+# Plan Created — User Report Format
+
+**MANDATORY**: after saving the plan file, display this report to the user in exactly this structure, filling every `{placeholder}` and dropping the `{If ...}` blocks that do not apply.
+
+```markdown
+## Plan Created
+
+**File**: `.claude/PRPs/plans/{feature-name}.plan.md`
+
+{If from PRD:}
+**Source PRD**: `{prd-file-path}`
+**Phase**: #{number} - {phase name}
+**PRD Updated**: Status set to `in-progress`, plan linked
+
+{If parallel phases available:}
+**Parallel Opportunity**: Phase {X} can run concurrently in a separate worktree.
+To start: `git worktree add -b phase-{X} ../project-phase-{X} && cd ../project-phase-{X} && /prp-plan {prd-path}`
+
+**Summary**: {2-3 sentence feature overview}
+
+**Complexity**: {LOW/MEDIUM/HIGH} - {brief rationale}
+
+**Scope**:
+- {N} files to CREATE
+- {M} files to UPDATE
+- {K} total tasks
+
+**Key Patterns Discovered**:
+- {Pattern 1 from codebase-explorer/analyst with file:line}
+- {Pattern 2 from codebase-explorer/analyst with file:line}
+
+**External Research**:
+- {Key doc 1 with version}
+- {Key doc 2 with version}
+
+**UX Transformation**:
+- BEFORE: {one-line current state}
+- AFTER: {one-line new state}
+
+**Risks**:
+- {Primary risk}: {mitigation}
+
+**Confidence Score**: {1-10}/10 for one-pass implementation success
+- {Rationale for score}
+
+**Next Step**: To execute, run: `/prp-implement .claude/PRPs/plans/{feature-name}.plan.md`
+```

--- a/.claude/skills/prp-plan/templates/ux-diagram-format.md
+++ b/.claude/skills/prp-plan/templates/ux-diagram-format.md
@@ -1,0 +1,49 @@
+# UX Transformation — Diagram & Table Format
+
+**MANDATORY** in Phase 4: produce the BEFORE/AFTER ASCII diagrams and the interaction-changes table in exactly this shape. Their content later fills the plan document's "UX Design" section.
+
+**CREATE ASCII diagrams showing user experience before and after:**
+
+```
+╔═══════════════════════════════════════════════════════════════════════════════╗
+║                              BEFORE STATE                                      ║
+╠═══════════════════════════════════════════════════════════════════════════════╣
+║                                                                               ║
+║   ┌─────────────┐         ┌─────────────┐         ┌─────────────┐            ║
+║   │   Screen/   │ ──────► │   Action    │ ──────► │   Result    │            ║
+║   │  Component  │         │   Current   │         │   Current   │            ║
+║   └─────────────┘         └─────────────┘         └─────────────┘            ║
+║                                                                               ║
+║   USER_FLOW: [describe current step-by-step experience]                       ║
+║   PAIN_POINT: [what's missing, broken, or inefficient]                        ║
+║   DATA_FLOW: [how data moves through the system currently]                    ║
+║                                                                               ║
+╚═══════════════════════════════════════════════════════════════════════════════╝
+
+╔═══════════════════════════════════════════════════════════════════════════════╗
+║                               AFTER STATE                                      ║
+╠═══════════════════════════════════════════════════════════════════════════════╣
+║                                                                               ║
+║   ┌─────────────┐         ┌─────────────┐         ┌─────────────┐            ║
+║   │   Screen/   │ ──────► │   Action    │ ──────► │   Result    │            ║
+║   │  Component  │         │    NEW      │         │    NEW      │            ║
+║   └─────────────┘         └─────────────┘         └─────────────┘            ║
+║                                   │                                           ║
+║                                   ▼                                           ║
+║                          ┌─────────────┐                                      ║
+║                          │ NEW_FEATURE │  ◄── [new capability added]          ║
+║                          └─────────────┘                                      ║
+║                                                                               ║
+║   USER_FLOW: [describe new step-by-step experience]                           ║
+║   VALUE_ADD: [what user gains from this change]                               ║
+║   DATA_FLOW: [how data moves through the system after]                        ║
+║                                                                               ║
+╚═══════════════════════════════════════════════════════════════════════════════╝
+```
+
+**DOCUMENT interaction changes:**
+
+| Location        | Before          | After       | User_Action | Impact        |
+| --------------- | --------------- | ----------- | ----------- | ------------- |
+| `/route`        | State A         | State B     | Click X     | Can now Y     |
+| `Component.tsx` | Missing feature | Has feature | Input Z     | Gets result W |

--- a/plugins/prp-core/skills/prp-plan/SKILL.md
+++ b/plugins/prp-core/skills/prp-plan/SKILL.md
@@ -131,49 +131,10 @@ So that <benefit/value>
 
 ## Phase 2: EXPLORE - Codebase Intelligence
 
-**CRITICAL: Launch two specialized agents in parallel using multiple Task tool calls in a single message.**
+**CRITICAL: Launch two specialized agents in parallel using multiple Task tool calls in a single message.** Read `references/agent-prompts.md` now (mandatory) — it is the exact prompt text for every subagent launch in Phases 2, 3, and 5.
 
-### Agent 1: `prp-core:codebase-explorer`
-
-Finds WHERE code lives and extracts implementation patterns.
-
-Use Task tool with `subagent_type="prp-core:codebase-explorer"`:
-
-```
-Find all code relevant to implementing: [feature description].
-
-LOCATE:
-1. Similar implementations - analogous features with file:line references
-2. Naming conventions - actual examples of function/class/file naming
-3. Error handling patterns - how errors are created, thrown, caught
-4. Logging patterns - logger usage, message formats
-5. Type definitions - relevant interfaces and types
-6. Test patterns - test file structure, assertion styles, test file locations
-7. Configuration - relevant config files and settings
-8. Dependencies - relevant libraries already in use
-
-Categorize findings by purpose (implementation, tests, config, types, docs).
-Return ACTUAL code snippets from codebase, not generic examples.
-```
-
-### Agent 2: `prp-core:codebase-analyst`
-
-Analyzes HOW integration points work and traces data flow.
-
-Use Task tool with `subagent_type="prp-core:codebase-analyst"`:
-
-```
-Analyze the implementation details relevant to: [feature description].
-
-TRACE:
-1. Entry points - where new code will connect to existing code
-2. Data flow - how data moves through related components
-3. State changes - side effects in related functions
-4. Contracts - interfaces and expectations between components
-5. Patterns in use - design patterns and architectural decisions
-
-Document what exists with precise file:line references. No suggestions or improvements.
-```
+- **Agent 1: `prp-core:codebase-explorer`** — finds WHERE code lives and extracts implementation patterns. Launch with the Phase 2 codebase-explorer prompt.
+- **Agent 2: `prp-core:codebase-analyst`** — analyzes HOW integration points work and traces data flow. Launch with the Phase 2 codebase-analyst prompt.
 
 ### Merge Agent Results
 
@@ -202,27 +163,7 @@ Combine findings from both agents into a unified discovery table:
 
 **ONLY AFTER Phase 2 is complete** - solutions must fit existing codebase patterns first.
 
-**Use Task tool with `subagent_type="prp-core:web-researcher"`:**
-
-```
-Research external documentation relevant to implementing: [feature description].
-
-FIND:
-1. Official documentation for involved libraries (match versions from package.json: [list relevant deps and versions])
-2. Known gotchas, breaking changes, deprecations for these versions
-3. Security considerations and best practices
-4. Performance optimization patterns
-
-VERSION CONSTRAINTS:
-- [library]: v{version} (from package.json)
-- [library]: v{version}
-
-Return findings with:
-- Direct links to specific doc sections (not just homepages)
-- Key insights that affect implementation
-- Gotchas with mitigation strategies
-- Any conflicts between docs and existing codebase patterns found in Phase 2
-```
+**Launch `prp-core:web-researcher`** with the Phase 3 web-researcher prompt from `references/agent-prompts.md`, filling in the feature description and the dependency versions found in Phase 2.
 
 **FORMAT the agent's findings into plan references:**
 
@@ -245,51 +186,7 @@ Return findings with:
 
 ## Phase 4: DESIGN - UX Transformation
 
-**CREATE ASCII diagrams showing user experience before and after:**
-
-```
-╔═══════════════════════════════════════════════════════════════════════════════╗
-║                              BEFORE STATE                                      ║
-╠═══════════════════════════════════════════════════════════════════════════════╣
-║                                                                               ║
-║   ┌─────────────┐         ┌─────────────┐         ┌─────────────┐            ║
-║   │   Screen/   │ ──────► │   Action    │ ──────► │   Result    │            ║
-║   │  Component  │         │   Current   │         │   Current   │            ║
-║   └─────────────┘         └─────────────┘         └─────────────┘            ║
-║                                                                               ║
-║   USER_FLOW: [describe current step-by-step experience]                       ║
-║   PAIN_POINT: [what's missing, broken, or inefficient]                        ║
-║   DATA_FLOW: [how data moves through the system currently]                    ║
-║                                                                               ║
-╚═══════════════════════════════════════════════════════════════════════════════╝
-
-╔═══════════════════════════════════════════════════════════════════════════════╗
-║                               AFTER STATE                                      ║
-╠═══════════════════════════════════════════════════════════════════════════════╣
-║                                                                               ║
-║   ┌─────────────┐         ┌─────────────┐         ┌─────────────┐            ║
-║   │   Screen/   │ ──────► │   Action    │ ──────► │   Result    │            ║
-║   │  Component  │         │    NEW      │         │    NEW      │            ║
-║   └─────────────┘         └─────────────┘         └─────────────┘            ║
-║                                   │                                           ║
-║                                   ▼                                           ║
-║                          ┌─────────────┐                                      ║
-║                          │ NEW_FEATURE │  ◄── [new capability added]          ║
-║                          └─────────────┘                                      ║
-║                                                                               ║
-║   USER_FLOW: [describe new step-by-step experience]                           ║
-║   VALUE_ADD: [what user gains from this change]                               ║
-║   DATA_FLOW: [how data moves through the system after]                        ║
-║                                                                               ║
-╚═══════════════════════════════════════════════════════════════════════════════╝
-```
-
-**DOCUMENT interaction changes:**
-
-| Location        | Before          | After       | User_Action | Impact        |
-| --------------- | --------------- | ----------- | ----------- | ------------- |
-| `/route`        | State A         | State B     | Click X     | Can now Y     |
-| `Component.tsx` | Missing feature | Has feature | Input Z     | Gets result W |
+**CREATE ASCII diagrams showing user experience before and after, then DOCUMENT interaction changes.** Read `templates/ux-diagram-format.md` now (mandatory) — it is the exact BEFORE/AFTER diagram shape and interaction-changes table to produce.
 
 **PHASE_4_CHECKPOINT:**
 
@@ -302,25 +199,7 @@ Return findings with:
 
 ## Phase 5: ARCHITECT - Strategic Design
 
-**For complex features with multiple integration points**, use `prp-core:codebase-analyst` to trace how existing architecture works at the integration points identified in Phase 2:
-
-Use Task tool with `subagent_type="prp-core:codebase-analyst"`:
-
-```
-Analyze the architecture around these integration points for: [feature description].
-
-INTEGRATION POINTS (from Phase 2):
-- [entry point 1 from explorer/analyst findings]
-- [entry point 2]
-
-ANALYZE:
-1. How data flows through each integration point
-2. What contracts exist between components
-3. What side effects occur at each stage
-4. What error handling patterns are in place
-
-Document what exists with precise file:line references. No suggestions.
-```
+**For complex features with multiple integration points**, use `prp-core:codebase-analyst` to trace how existing architecture works at the integration points identified in Phase 2 — launch with the Phase 5 architecture deep-dive prompt from `references/agent-prompts.md`.
 
 **Then ANALYZE deeply (use extended thinking if needed):**
 
@@ -363,7 +242,7 @@ NOT_BUILDING (explicit scope limits):
 
 Create directory if needed: `mkdir -p .claude/PRPs/plans`
 
-**PLAN_STRUCTURE**: Read `templates/plan-template.md` now (mandatory) — it is the exact plan document to fill and save. Keep every section heading; fill every `{placeholder}` with real, project-specific content (the template's task entries and snippets are illustrative examples from one TypeScript project, not content to keep).
+**PLAN_STRUCTURE**: Read `templates/plan-template.md` now (mandatory) — it is the exact plan document to fill and save. Keep every section heading; fill every `{placeholder}` with real, project-specific content (the template's remaining snippets and table entries are illustrative examples from one TypeScript project, not content to keep). Before writing the plan's Step-by-Step Tasks section, read `references/task-block-format.md` (mandatory) for the task-block field detail and worked examples; before filling its Validation Commands section, read `references/validation-commands.md` (mandatory) for the per-language commands to embed.
 
 </process>
 
@@ -378,51 +257,7 @@ Create directory if needed: `mkdir -p .claude/PRPs/plans`
 
 2. **Edit the PRD file** with these changes
 
-**REPORT_TO_USER** (display after creating plan):
-
-```markdown
-## Plan Created
-
-**File**: `.claude/PRPs/plans/{feature-name}.plan.md`
-
-{If from PRD:}
-**Source PRD**: `{prd-file-path}`
-**Phase**: #{number} - {phase name}
-**PRD Updated**: Status set to `in-progress`, plan linked
-
-{If parallel phases available:}
-**Parallel Opportunity**: Phase {X} can run concurrently in a separate worktree.
-To start: `git worktree add -b phase-{X} ../project-phase-{X} && cd ../project-phase-{X} && /prp-plan {prd-path}`
-
-**Summary**: {2-3 sentence feature overview}
-
-**Complexity**: {LOW/MEDIUM/HIGH} - {brief rationale}
-
-**Scope**:
-- {N} files to CREATE
-- {M} files to UPDATE
-- {K} total tasks
-
-**Key Patterns Discovered**:
-- {Pattern 1 from codebase-explorer/analyst with file:line}
-- {Pattern 2 from codebase-explorer/analyst with file:line}
-
-**External Research**:
-- {Key doc 1 with version}
-- {Key doc 2 with version}
-
-**UX Transformation**:
-- BEFORE: {one-line current state}
-- AFTER: {one-line new state}
-
-**Risks**:
-- {Primary risk}: {mitigation}
-
-**Confidence Score**: {1-10}/10 for one-pass implementation success
-- {Rationale for score}
-
-**Next Step**: To execute, run: `/prp-implement .claude/PRPs/plans/{feature-name}.plan.md`
-```
+**REPORT_TO_USER** (display after creating plan): Read `templates/report-format.md` now (mandatory) and display the "Plan Created" report in exactly that structure.
 
 </output>
 
@@ -478,5 +313,10 @@ To start: `git worktree add -b phase-{X} ../project-phase-{X} && cd ../project-p
 
 ## Resources
 
-- `templates/plan-template.md` — the plan document to fill and save (read in Phase 6)
+- `references/agent-prompts.md` — exact subagent prompts for Phases 2, 3, and 5 (mandatory read at Phase 2)
+- `templates/plan-template.md` — the plan document to fill and save (mandatory read in Phase 6)
+- `templates/ux-diagram-format.md` — the BEFORE/AFTER ASCII diagram shape and interaction-changes table (mandatory read in Phase 4)
+- `templates/report-format.md` — the "Plan Created" report displayed to the user (mandatory read in Output)
+- `references/task-block-format.md` — task-block field detail and worked examples (mandatory read in Phase 6, before writing Step-by-Step Tasks)
+- `references/validation-commands.md` — per-language validation command catalog (mandatory read in Phase 6, before filling Validation Commands)
 - `workflows/update-references.md` — the update-references mode (read only when Mode Select routes there)

--- a/plugins/prp-core/skills/prp-plan/references/agent-prompts.md
+++ b/plugins/prp-core/skills/prp-plan/references/agent-prompts.md
@@ -1,0 +1,85 @@
+# Subagent Prompts — Intelligence Gathering
+
+The exact prompt text for every subagent launch in Phases 2, 3, and 5. Fill the `[bracketed]` slots before sending; do not otherwise reword the prompts.
+
+## Phase 2 — codebase-explorer prompt
+
+Use Task tool with `subagent_type="prp-core:codebase-explorer"`:
+
+```
+Find all code relevant to implementing: [feature description].
+
+LOCATE:
+1. Similar implementations - analogous features with file:line references
+2. Naming conventions - actual examples of function/class/file naming
+3. Error handling patterns - how errors are created, thrown, caught
+4. Logging patterns - logger usage, message formats
+5. Type definitions - relevant interfaces and types
+6. Test patterns - test file structure, assertion styles, test file locations
+7. Configuration - relevant config files and settings
+8. Dependencies - relevant libraries already in use
+
+Categorize findings by purpose (implementation, tests, config, types, docs).
+Return ACTUAL code snippets from codebase, not generic examples.
+```
+
+## Phase 2 — codebase-analyst prompt
+
+Use Task tool with `subagent_type="prp-core:codebase-analyst"`:
+
+```
+Analyze the implementation details relevant to: [feature description].
+
+TRACE:
+1. Entry points - where new code will connect to existing code
+2. Data flow - how data moves through related components
+3. State changes - side effects in related functions
+4. Contracts - interfaces and expectations between components
+5. Patterns in use - design patterns and architectural decisions
+
+Document what exists with precise file:line references. No suggestions or improvements.
+```
+
+## Phase 3 — web-researcher prompt
+
+Use Task tool with `subagent_type="prp-core:web-researcher"`:
+
+```
+Research external documentation relevant to implementing: [feature description].
+
+FIND:
+1. Official documentation for involved libraries (match versions from package.json: [list relevant deps and versions])
+2. Known gotchas, breaking changes, deprecations for these versions
+3. Security considerations and best practices
+4. Performance optimization patterns
+
+VERSION CONSTRAINTS:
+- [library]: v{version} (from package.json)
+- [library]: v{version}
+
+Return findings with:
+- Direct links to specific doc sections (not just homepages)
+- Key insights that affect implementation
+- Gotchas with mitigation strategies
+- Any conflicts between docs and existing codebase patterns found in Phase 2
+```
+
+## Phase 5 — architecture deep-dive prompt
+
+Use Task tool with `subagent_type="prp-core:codebase-analyst"`:
+
+```
+Analyze the architecture around these integration points for: [feature description].
+
+INTEGRATION POINTS (from Phase 2):
+- [entry point 1 from explorer/analyst findings]
+- [entry point 2]
+
+ANALYZE:
+1. How data flows through each integration point
+2. What contracts exist between components
+3. What side effects occur at each stage
+4. What error handling patterns are in place
+
+Document what exists with precise file:line references. No suggestions.
+```

--- a/plugins/prp-core/skills/prp-plan/references/task-block-format.md
+++ b/plugins/prp-core/skills/prp-plan/references/task-block-format.md
@@ -1,0 +1,92 @@
+# Task Block Format — Field Detail & Worked Examples
+
+How to write the entries in the plan's "Step-by-Step Tasks" section. The section skeleton (status markers + the generic task block) lives in `templates/plan-template.md`; this file holds the field-by-field detail and a full worked example sequence.
+
+## Fields
+
+Each task is a bullet list under a `### `[ ]` Task N: {ACTION} `{file}`` header. Use the fields that apply:
+
+- **ACTION** — what to do to the file (CREATE / UPDATE / ADD ...)
+- **IMPLEMENT** — the specific content to implement (functions, columns, schemas)
+- **MIRROR** — `file:line` of the existing codebase pattern to copy exactly
+- **IMPORTS** — exact import statements the new code needs
+- **TYPES** — type definitions or inference patterns to use
+- **PATTERN** — the design pattern or structural rule to follow
+- **GOTCHA** — known issue to avoid, discovered in Phase 2/3 research
+- **VALIDATE** — executable command proving the task is done
+
+Every task MUST have at least MIRROR (or PATTERN) and VALIDATE. GOTCHA entries come from real research findings, not invented warnings.
+
+## Worked example sequence
+
+Illustrative examples from one TypeScript project — replace their content entirely with the target project's real files, patterns, and commands. Note the dependency order: schema → types → validation → errors → repository → service → public API → tests.
+
+### `[ ]` Task 1: UPDATE `src/core/database/schema.ts`
+
+- **ACTION**: ADD table definition to schema
+- **IMPLEMENT**: {specific columns, types, constraints}
+- **MIRROR**: `src/core/database/schema.ts:XX-YY` - follow existing table pattern
+- **IMPORTS**: `import { pgTable, text, timestamp } from "drizzle-orm/pg-core"`
+- **GOTCHA**: {known issue to avoid, e.g., "use uuid for id, not serial"}
+- **VALIDATE**: `npx tsc --noEmit` - types must compile
+
+### `[ ]` Task 2: CREATE `src/features/new/models.ts`
+
+- **ACTION**: CREATE type definitions file
+- **IMPLEMENT**: Re-export table, define inferred types
+- **MIRROR**: `src/features/projects/models.ts:1-10`
+- **IMPORTS**: `import { things } from "@/core/database/schema"`
+- **TYPES**: `type Thing = typeof things.$inferSelect`
+- **GOTCHA**: Use `$inferSelect` for read types, `$inferInsert` for write
+- **VALIDATE**: `npx tsc --noEmit`
+
+### `[ ]` Task 3: CREATE `src/features/new/schemas.ts`
+
+- **ACTION**: CREATE Zod validation schemas
+- **IMPLEMENT**: CreateThingSchema, UpdateThingSchema
+- **MIRROR**: `src/features/projects/schemas.ts:1-30`
+- **IMPORTS**: `import { z } from "zod/v4"` (note: zod/v4 not zod)
+- **GOTCHA**: z.record requires two args in v4
+- **VALIDATE**: `npx tsc --noEmit`
+
+### `[ ]` Task 4: CREATE `src/features/new/errors.ts`
+
+- **ACTION**: CREATE feature-specific error classes
+- **IMPLEMENT**: ThingNotFoundError, ThingAccessDeniedError
+- **MIRROR**: `src/features/projects/errors.ts:1-40`
+- **PATTERN**: Extend base Error, include code and statusCode
+- **VALIDATE**: `npx tsc --noEmit`
+
+### `[ ]` Task 5: CREATE `src/features/new/repository.ts`
+
+- **ACTION**: CREATE database operations
+- **IMPLEMENT**: findById, findByUserId, create, update, delete
+- **MIRROR**: `src/features/projects/repository.ts:1-60`
+- **IMPORTS**: `import { db } from "@/core/database/client"`
+- **GOTCHA**: Use `results[0]` pattern, not `.first()` - check noUncheckedIndexedAccess
+- **VALIDATE**: `npx tsc --noEmit`
+
+### `[ ]` Task 6: CREATE `src/features/new/service.ts`
+
+- **ACTION**: CREATE business logic layer
+- **IMPLEMENT**: createThing, getThing, updateThing, deleteThing
+- **MIRROR**: `src/features/projects/service.ts:1-80`
+- **PATTERN**: Use repository, add logging, throw custom errors
+- **IMPORTS**: `import { getLogger } from "@/core/logging"`
+- **VALIDATE**: `{type-check-cmd} && {lint-cmd}`
+
+### `[ ]` Task 7: CREATE `{source-dir}/features/new/index.ts`
+
+- **ACTION**: CREATE public API exports
+- **IMPLEMENT**: Export types, schemas, errors, service functions
+- **MIRROR**: `{source-dir}/features/{example}/index.ts:1-20`
+- **PATTERN**: Named exports only, hide repository (internal)
+- **VALIDATE**: `{type-check-cmd}`
+
+### `[ ]` Task 8: CREATE `{source-dir}/features/new/tests/service.test.ts`
+
+- **ACTION**: CREATE unit tests for service
+- **IMPLEMENT**: Test each service function, happy path + error cases
+- **MIRROR**: `{source-dir}/features/{example}/tests/service.test.ts:1-100`
+- **PATTERN**: Use project's test framework (jest, vitest, bun:test, pytest, etc.)
+- **VALIDATE**: `{test-cmd} {path-to-tests}`

--- a/plugins/prp-core/skills/prp-plan/references/validation-commands.md
+++ b/plugins/prp-core/skills/prp-plan/references/validation-commands.md
@@ -1,0 +1,19 @@
+# Validation Commands — Per-Language Catalog
+
+Concrete commands to substitute for the `{runner}` placeholders in the plan's "Validation Commands" section (see the level structure in `templates/plan-template.md`). Always replace placeholders with actual commands from the project's package.json/config — verify the script names exist before embedding them.
+
+## Level 1: STATIC_ANALYSIS
+
+Examples: `npm run lint`, `pnpm lint`, `ruff check . && mypy .`, `cargo clippy`
+
+## Level 2: UNIT_TESTS
+
+Examples: `npm test`, `pytest tests/`, `cargo test`, `go test ./...`
+
+## Level 3: FULL_SUITE
+
+Examples: `npm test && npm run build`, `cargo test && cargo build`
+
+## Levels 4-6
+
+Levels 4 (DATABASE_VALIDATION), 5 (BROWSER_VALIDATION), and 6 (MANUAL_VALIDATION) have no generic catalog — they are project-specific MCP tooling (e.g. Supabase MCP, Browser MCP) or step-by-step manual checks, as shaped in the plan template. Include them only where applicable.

--- a/plugins/prp-core/skills/prp-plan/templates/plan-template.md
+++ b/plugins/prp-core/skills/prp-plan/templates/plan-template.md
@@ -169,75 +169,16 @@ Execute in order. Each task is atomic and independently verifiable.
 
 **Status markers** — prefix EVERY task header with one; the build agent updates it inline as it works: `[ ]` idle · `[wip]` in progress · `[x]` complete · `[f]` failed. All tasks start `[ ]`. If a task cannot be made to pass, mark it `[f]`, record why in Agent Notes, and move on if the rest of the plan can still proceed.
 
-### `[ ]` Task 1: UPDATE `src/core/database/schema.ts`
+### `[ ]` Task {N}: {ACTION} `{path/to/file}`
 
-- **ACTION**: ADD table definition to schema
-- **IMPLEMENT**: {specific columns, types, constraints}
-- **MIRROR**: `src/core/database/schema.ts:XX-YY` - follow existing table pattern
-- **IMPORTS**: `import { pgTable, text, timestamp } from "drizzle-orm/pg-core"`
-- **GOTCHA**: {known issue to avoid, e.g., "use uuid for id, not serial"}
-- **VALIDATE**: `npx tsc --noEmit` - types must compile
+- **ACTION**: {what to do to this file - CREATE / UPDATE / ADD ...}
+- **IMPLEMENT**: {the specific content to implement}
+- **MIRROR**: `{path/to/analogous/file:lines}` - {existing pattern to copy exactly}
+- **IMPORTS**: {exact import statements the new code needs}
+- **GOTCHA**: {known issue to avoid, from research findings}
+- **VALIDATE**: `{executable command proving the task is done}`
 
-### `[ ]` Task 2: CREATE `src/features/new/models.ts`
-
-- **ACTION**: CREATE type definitions file
-- **IMPLEMENT**: Re-export table, define inferred types
-- **MIRROR**: `src/features/projects/models.ts:1-10`
-- **IMPORTS**: `import { things } from "@/core/database/schema"`
-- **TYPES**: `type Thing = typeof things.$inferSelect`
-- **GOTCHA**: Use `$inferSelect` for read types, `$inferInsert` for write
-- **VALIDATE**: `npx tsc --noEmit`
-
-### `[ ]` Task 3: CREATE `src/features/new/schemas.ts`
-
-- **ACTION**: CREATE Zod validation schemas
-- **IMPLEMENT**: CreateThingSchema, UpdateThingSchema
-- **MIRROR**: `src/features/projects/schemas.ts:1-30`
-- **IMPORTS**: `import { z } from "zod/v4"` (note: zod/v4 not zod)
-- **GOTCHA**: z.record requires two args in v4
-- **VALIDATE**: `npx tsc --noEmit`
-
-### `[ ]` Task 4: CREATE `src/features/new/errors.ts`
-
-- **ACTION**: CREATE feature-specific error classes
-- **IMPLEMENT**: ThingNotFoundError, ThingAccessDeniedError
-- **MIRROR**: `src/features/projects/errors.ts:1-40`
-- **PATTERN**: Extend base Error, include code and statusCode
-- **VALIDATE**: `npx tsc --noEmit`
-
-### `[ ]` Task 5: CREATE `src/features/new/repository.ts`
-
-- **ACTION**: CREATE database operations
-- **IMPLEMENT**: findById, findByUserId, create, update, delete
-- **MIRROR**: `src/features/projects/repository.ts:1-60`
-- **IMPORTS**: `import { db } from "@/core/database/client"`
-- **GOTCHA**: Use `results[0]` pattern, not `.first()` - check noUncheckedIndexedAccess
-- **VALIDATE**: `npx tsc --noEmit`
-
-### `[ ]` Task 6: CREATE `src/features/new/service.ts`
-
-- **ACTION**: CREATE business logic layer
-- **IMPLEMENT**: createThing, getThing, updateThing, deleteThing
-- **MIRROR**: `src/features/projects/service.ts:1-80`
-- **PATTERN**: Use repository, add logging, throw custom errors
-- **IMPORTS**: `import { getLogger } from "@/core/logging"`
-- **VALIDATE**: `{type-check-cmd} && {lint-cmd}`
-
-### `[ ]` Task 7: CREATE `{source-dir}/features/new/index.ts`
-
-- **ACTION**: CREATE public API exports
-- **IMPLEMENT**: Export types, schemas, errors, service functions
-- **MIRROR**: `{source-dir}/features/{example}/index.ts:1-20`
-- **PATTERN**: Named exports only, hide repository (internal)
-- **VALIDATE**: `{type-check-cmd}`
-
-### `[ ]` Task 8: CREATE `{source-dir}/features/new/tests/service.test.ts`
-
-- **ACTION**: CREATE unit tests for service
-- **IMPLEMENT**: Test each service function, happy path + error cases
-- **MIRROR**: `{source-dir}/features/{example}/tests/service.test.ts:1-100`
-- **PATTERN**: Use project's test framework (jest, vitest, bun:test, pytest, etc.)
-- **VALIDATE**: `{test-cmd} {path-to-tests}`
+{Repeat one block per task, in dependency order, numbered from 1.}
 
 ---
 
@@ -272,7 +213,6 @@ Execute in order. Each task is atomic and independently verifiable.
 
 ```bash
 {runner} run lint && {runner} run type-check
-# Examples: npm run lint, pnpm lint, ruff check . && mypy ., cargo clippy
 ```
 
 **EXPECT**: Exit 0, no errors or warnings
@@ -281,7 +221,6 @@ Execute in order. Each task is atomic and independently verifiable.
 
 ```bash
 {runner} test {path/to/feature/tests}
-# Examples: npm test, pytest tests/, cargo test, go test ./...
 ```
 
 **EXPECT**: All tests pass, coverage >= 80%
@@ -290,7 +229,6 @@ Execute in order. Each task is atomic and independently verifiable.
 
 ```bash
 {runner} test && {runner} run build
-# Examples: npm test && npm run build, cargo test && cargo build
 ```
 
 **EXPECT**: All tests pass, build succeeds

--- a/plugins/prp-core/skills/prp-plan/templates/report-format.md
+++ b/plugins/prp-core/skills/prp-plan/templates/report-format.md
@@ -1,0 +1,47 @@
+# Plan Created — User Report Format
+
+**MANDATORY**: after saving the plan file, display this report to the user in exactly this structure, filling every `{placeholder}` and dropping the `{If ...}` blocks that do not apply.
+
+```markdown
+## Plan Created
+
+**File**: `.claude/PRPs/plans/{feature-name}.plan.md`
+
+{If from PRD:}
+**Source PRD**: `{prd-file-path}`
+**Phase**: #{number} - {phase name}
+**PRD Updated**: Status set to `in-progress`, plan linked
+
+{If parallel phases available:}
+**Parallel Opportunity**: Phase {X} can run concurrently in a separate worktree.
+To start: `git worktree add -b phase-{X} ../project-phase-{X} && cd ../project-phase-{X} && /prp-plan {prd-path}`
+
+**Summary**: {2-3 sentence feature overview}
+
+**Complexity**: {LOW/MEDIUM/HIGH} - {brief rationale}
+
+**Scope**:
+- {N} files to CREATE
+- {M} files to UPDATE
+- {K} total tasks
+
+**Key Patterns Discovered**:
+- {Pattern 1 from codebase-explorer/analyst with file:line}
+- {Pattern 2 from codebase-explorer/analyst with file:line}
+
+**External Research**:
+- {Key doc 1 with version}
+- {Key doc 2 with version}
+
+**UX Transformation**:
+- BEFORE: {one-line current state}
+- AFTER: {one-line new state}
+
+**Risks**:
+- {Primary risk}: {mitigation}
+
+**Confidence Score**: {1-10}/10 for one-pass implementation success
+- {Rationale for score}
+
+**Next Step**: To execute, run: `/prp-implement .claude/PRPs/plans/{feature-name}.plan.md`
+```

--- a/plugins/prp-core/skills/prp-plan/templates/ux-diagram-format.md
+++ b/plugins/prp-core/skills/prp-plan/templates/ux-diagram-format.md
@@ -1,0 +1,49 @@
+# UX Transformation — Diagram & Table Format
+
+**MANDATORY** in Phase 4: produce the BEFORE/AFTER ASCII diagrams and the interaction-changes table in exactly this shape. Their content later fills the plan document's "UX Design" section.
+
+**CREATE ASCII diagrams showing user experience before and after:**
+
+```
+╔═══════════════════════════════════════════════════════════════════════════════╗
+║                              BEFORE STATE                                      ║
+╠═══════════════════════════════════════════════════════════════════════════════╣
+║                                                                               ║
+║   ┌─────────────┐         ┌─────────────┐         ┌─────────────┐            ║
+║   │   Screen/   │ ──────► │   Action    │ ──────► │   Result    │            ║
+║   │  Component  │         │   Current   │         │   Current   │            ║
+║   └─────────────┘         └─────────────┘         └─────────────┘            ║
+║                                                                               ║
+║   USER_FLOW: [describe current step-by-step experience]                       ║
+║   PAIN_POINT: [what's missing, broken, or inefficient]                        ║
+║   DATA_FLOW: [how data moves through the system currently]                    ║
+║                                                                               ║
+╚═══════════════════════════════════════════════════════════════════════════════╝
+
+╔═══════════════════════════════════════════════════════════════════════════════╗
+║                               AFTER STATE                                      ║
+╠═══════════════════════════════════════════════════════════════════════════════╣
+║                                                                               ║
+║   ┌─────────────┐         ┌─────────────┐         ┌─────────────┐            ║
+║   │   Screen/   │ ──────► │   Action    │ ──────► │   Result    │            ║
+║   │  Component  │         │    NEW      │         │    NEW      │            ║
+║   └─────────────┘         └─────────────┘         └─────────────┘            ║
+║                                   │                                           ║
+║                                   ▼                                           ║
+║                          ┌─────────────┐                                      ║
+║                          │ NEW_FEATURE │  ◄── [new capability added]          ║
+║                          └─────────────┘                                      ║
+║                                                                               ║
+║   USER_FLOW: [describe new step-by-step experience]                           ║
+║   VALUE_ADD: [what user gains from this change]                               ║
+║   DATA_FLOW: [how data moves through the system after]                        ║
+║                                                                               ║
+╚═══════════════════════════════════════════════════════════════════════════════╝
+```
+
+**DOCUMENT interaction changes:**
+
+| Location        | Before          | After       | User_Action | Impact        |
+| --------------- | --------------- | ----------- | ----------- | ------------- |
+| `/route`        | State A         | State B     | Click X     | Can now Y     |
+| `Component.tsx` | Missing feature | Has feature | Input Z     | Gets result W |


### PR DESCRIPTION
## What

Performs the split that `prp-meta-skill`'s `references/refactoring-skills.md` documents as its worked before/after example for prp-plan, which had never actually been done. Strictly behavior-preserving: same phases, same prompts, same plan output — content relocated verbatim, never reworded.

## Changes

**New references (extracted verbatim):**
- `references/task-block-format.md` — task-block field detail (MIRROR/IMPORTS/GOTCHA/…) + the 8 worked example tasks, from the plan template; the template keeps a generic task block with the same field vocabulary
- `references/validation-commands.md` — per-language command catalog, from the template's Level 1–3 example lines
- `references/agent-prompts.md` — the four subagent prompts (Phases 2, 3, 5), from the body

**New templates (extracted verbatim from the body):**
- `templates/ux-diagram-format.md` — Phase 4 BEFORE/AFTER ASCII diagram shape + interaction-changes table
- `templates/report-format.md` — the "Plan Created" user report

**Wiring:** every extraction gets a mandatory-read pointer at its point of use (per the meta-skill's warning about always-needed output shapes behind lazy pointers). All resources listed in the Resources section; `workflows/update-references.md` untouched.

**Size:** SKILL.md body ~2,350 → 1,849 words (target range 1,500–2,000), spine (Mode Select + Phases 0–6 + verification) intact.

## Validation

- Meta-skill gates 1–6 pass: pointers all resolve, no body/resource duplication, imperative voice, body in range
- Gate 5 (behavior preservation): extraction diffed verbatim against the originals; independent `plugin-dev:skill-reviewer` run confirmed no content loss or drift (its one actionable finding — pointer strength on the two Phase 6 references — applied)
- `python3 scripts/sync_plugin.py --check` passes; regenerated `plugins/prp-core/skills/prp-plan/` mirror included