### PR TITLE
feat(prp-core): add prp-diagram — mermaid supplements for plan artifacts

### DIFF
--- a/.agents/skills/prp-diagram/SKILL.md
+++ b/.agents/skills/prp-diagram/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: prp-diagram
+description: Generate a mermaid-only visual supplement for a plan artifact - the data-model, architecture, and flow diagrams a human wants when absorbing a plan. Use when the user wants to "diagram this plan", "visualize the plan", "draw the plan's architecture", "make diagrams for this plan", or invokes $prp-diagram.
+---
+
+> **Arguments:** `$ARGUMENTS` (and `$1`, `$2`, ...) refer to the arguments given when this skill was invoked. Take them from the user's request; if absent, infer them from the conversation.
+
+# PRP Diagram — Visual Supplement for a Plan
+
+**Input**: $ARGUMENTS — a path to a plan/PRD markdown file. If blank, use the most recent file in `$PRP_DIR/plans/`.
+
+One agent, one pass, no subagents. Read the plan, produce the diagrams a human wants beside it while absorbing it. Nothing else.
+
+## Resolve the store
+
+```bash
+# --- PRP store resolver (canonical; keep byte-identical across skills) ---
+_gd="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"
+case "$_gd" in */.git) _root="${_gd%/.git}" ;; "") _root="$PWD" ;; *) _root="$_gd" ;; esac
+_root="$(cd "$_root" && pwd -P)"
+_name="$(basename "$_root" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | sed 's/^-*//;s/-*$//')"
+PRP_DIR="${PRP_HOME:-$HOME/.prp}/${_name:-project}-$(printf %s "$_root" | git hash-object --stdin | cut -c1-8)"
+mkdir -p "$PRP_DIR"; [ -f "$PRP_DIR/project.json" ] || printf '{"path": "%s", "name": "%s"}\n' "$_root" "${_name:-project}" > "$PRP_DIR/project.json"
+```
+
+## Output path
+
+`<plan-basename>.diagrams.md` — strip the plan filename's trailing `.md`, append `.diagrams.md`.
+
+- Plan lives inside `$PRP_DIR` → write NEXT TO it (same directory).
+- Plan lives anywhere else → write to `$PRP_DIR/plans/` (`mkdir -p "$PRP_DIR/plans"`).
+
+Overwrite on re-run without asking — this is a derived artifact; the plan is the source of truth.
+
+## Content policy (strict)
+
+The file contains ONLY:
+
+1. A single title line: `# <plan title> — Diagrams`
+2. Per diagram: one bold caption line (`**<what this shows>**`), then one ```mermaid fence.
+
+No prose paragraphs, no recommendations, no analysis, no legend sections. Diagrams supplement the plan — they never editorialize it.
+
+## Choosing diagrams
+
+Diagram only what the plan actually contains — never invent entities, flows, or states the plan doesn't describe. Skip any category the plan doesn't support.
+
+| Plan content | Diagram type |
+|---|---|
+| Data-model changes (tables, entities, types, relations) | `erDiagram` or `classDiagram` |
+| Architecture/component changes | `flowchart` — before/after subgraphs when the plan describes both states |
+| Key flows (request paths, pipelines, interactions) | `sequenceDiagram` |
+| Lifecycle/state rules | `stateDiagram-v2` |
+
+Keep each diagram legible: ~40 nodes max — split into two diagrams rather than cram one. Mermaid syntax must be valid: prefer simple constructs over clever ones, and quote labels containing special characters (`A["label (with) specials"]`).
+
+## HTML alternative
+
+Only when the user explicitly asks for `.html`: write a single self-contained html file at the same path with `.diagrams.html` instead. Same content policy — a title, then per diagram a caption and a `<pre class="mermaid">` block. Do NOT embed or link mermaid.js (no CDN, no scripts) — the consuming UI provides the renderer; add an html comment noting that.
+
+## Report
+
+One line to the user: the expanded absolute output path plus which diagram types were produced.

--- a/.claude/skills/prp-diagram/SKILL.md
+++ b/.claude/skills/prp-diagram/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: prp-diagram
+description: Generate a mermaid-only visual supplement for a plan artifact - the data-model, architecture, and flow diagrams a human wants when absorbing a plan. Use when the user wants to "diagram this plan", "visualize the plan", "draw the plan's architecture", "make diagrams for this plan", or invokes /prp-diagram.
+argument-hint: "[path/to/plan.md] (blank = most recent plan in the store)"
+---
+
+# PRP Diagram — Visual Supplement for a Plan
+
+**Input**: $ARGUMENTS — a path to a plan/PRD markdown file. If blank, use the most recent file in `$PRP_DIR/plans/`.
+
+One agent, one pass, no subagents. Read the plan, produce the diagrams a human wants beside it while absorbing it. Nothing else.
+
+## Resolve the store
+
+```bash
+# --- PRP store resolver (canonical; keep byte-identical across skills) ---
+_gd="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"
+case "$_gd" in */.git) _root="${_gd%/.git}" ;; "") _root="$PWD" ;; *) _root="$_gd" ;; esac
+_root="$(cd "$_root" && pwd -P)"
+_name="$(basename "$_root" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | sed 's/^-*//;s/-*$//')"
+PRP_DIR="${PRP_HOME:-$HOME/.prp}/${_name:-project}-$(printf %s "$_root" | git hash-object --stdin | cut -c1-8)"
+mkdir -p "$PRP_DIR"; [ -f "$PRP_DIR/project.json" ] || printf '{"path": "%s", "name": "%s"}\n' "$_root" "${_name:-project}" > "$PRP_DIR/project.json"
+```
+
+## Output path
+
+`<plan-basename>.diagrams.md` — strip the plan filename's trailing `.md`, append `.diagrams.md`.
+
+- Plan lives inside `$PRP_DIR` → write NEXT TO it (same directory).
+- Plan lives anywhere else → write to `$PRP_DIR/plans/` (`mkdir -p "$PRP_DIR/plans"`).
+
+Overwrite on re-run without asking — this is a derived artifact; the plan is the source of truth.
+
+## Content policy (strict)
+
+The file contains ONLY:
+
+1. A single title line: `# <plan title> — Diagrams`
+2. Per diagram: one bold caption line (`**<what this shows>**`), then one ```mermaid fence.
+
+No prose paragraphs, no recommendations, no analysis, no legend sections. Diagrams supplement the plan — they never editorialize it.
+
+## Choosing diagrams
+
+Diagram only what the plan actually contains — never invent entities, flows, or states the plan doesn't describe. Skip any category the plan doesn't support.
+
+| Plan content | Diagram type |
+|---|---|
+| Data-model changes (tables, entities, types, relations) | `erDiagram` or `classDiagram` |
+| Architecture/component changes | `flowchart` — before/after subgraphs when the plan describes both states |
+| Key flows (request paths, pipelines, interactions) | `sequenceDiagram` |
+| Lifecycle/state rules | `stateDiagram-v2` |
+
+Keep each diagram legible: ~40 nodes max — split into two diagrams rather than cram one. Mermaid syntax must be valid: prefer simple constructs over clever ones, and quote labels containing special characters (`A["label (with) specials"]`).
+
+## HTML alternative
+
+Only when the user explicitly asks for `.html`: write a single self-contained html file at the same path with `.diagrams.html` instead. Same content policy — a title, then per diagram a caption and a `<pre class="mermaid">` block. Do NOT embed or link mermaid.js (no CDN, no scripts) — the consuming UI provides the renderer; add an html comment noting that.
+
+## Report
+
+One line to the user: the expanded absolute output path plus which diagram types were produced.

--- a/plugins/prp-core/skills/prp-diagram/SKILL.md
+++ b/plugins/prp-core/skills/prp-diagram/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: prp-diagram
+description: Generate a mermaid-only visual supplement for a plan artifact - the data-model, architecture, and flow diagrams a human wants when absorbing a plan. Use when the user wants to "diagram this plan", "visualize the plan", "draw the plan's architecture", "make diagrams for this plan", or invokes /prp-diagram.
+argument-hint: "[path/to/plan.md] (blank = most recent plan in the store)"
+---
+
+# PRP Diagram — Visual Supplement for a Plan
+
+**Input**: $ARGUMENTS — a path to a plan/PRD markdown file. If blank, use the most recent file in `$PRP_DIR/plans/`.
+
+One agent, one pass, no subagents. Read the plan, produce the diagrams a human wants beside it while absorbing it. Nothing else.
+
+## Resolve the store
+
+```bash
+# --- PRP store resolver (canonical; keep byte-identical across skills) ---
+_gd="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"
+case "$_gd" in */.git) _root="${_gd%/.git}" ;; "") _root="$PWD" ;; *) _root="$_gd" ;; esac
+_root="$(cd "$_root" && pwd -P)"
+_name="$(basename "$_root" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | sed 's/^-*//;s/-*$//')"
+PRP_DIR="${PRP_HOME:-$HOME/.prp}/${_name:-project}-$(printf %s "$_root" | git hash-object --stdin | cut -c1-8)"
+mkdir -p "$PRP_DIR"; [ -f "$PRP_DIR/project.json" ] || printf '{"path": "%s", "name": "%s"}\n' "$_root" "${_name:-project}" > "$PRP_DIR/project.json"
+```
+
+## Output path
+
+`<plan-basename>.diagrams.md` — strip the plan filename's trailing `.md`, append `.diagrams.md`.
+
+- Plan lives inside `$PRP_DIR` → write NEXT TO it (same directory).
+- Plan lives anywhere else → write to `$PRP_DIR/plans/` (`mkdir -p "$PRP_DIR/plans"`).
+
+Overwrite on re-run without asking — this is a derived artifact; the plan is the source of truth.
+
+## Content policy (strict)
+
+The file contains ONLY:
+
+1. A single title line: `# <plan title> — Diagrams`
+2. Per diagram: one bold caption line (`**<what this shows>**`), then one ```mermaid fence.
+
+No prose paragraphs, no recommendations, no analysis, no legend sections. Diagrams supplement the plan — they never editorialize it.
+
+## Choosing diagrams
+
+Diagram only what the plan actually contains — never invent entities, flows, or states the plan doesn't describe. Skip any category the plan doesn't support.
+
+| Plan content | Diagram type |
+|---|---|
+| Data-model changes (tables, entities, types, relations) | `erDiagram` or `classDiagram` |
+| Architecture/component changes | `flowchart` — before/after subgraphs when the plan describes both states |
+| Key flows (request paths, pipelines, interactions) | `sequenceDiagram` |
+| Lifecycle/state rules | `stateDiagram-v2` |
+
+Keep each diagram legible: ~40 nodes max — split into two diagrams rather than cram one. Mermaid syntax must be valid: prefer simple constructs over clever ones, and quote labels containing special characters (`A["label (with) specials"]`).
+
+## HTML alternative
+
+Only when the user explicitly asks for `.html`: write a single self-contained html file at the same path with `.diagrams.html` instead. Same content policy — a title, then per diagram a caption and a `<pre class="mermaid">` block. Do NOT embed or link mermaid.js (no CDN, no scripts) — the consuming UI provides the renderer; add an html comment noting that.
+
+## Report
+
+One line to the user: the expanded absolute output path plus which diagram types were produced.


### PR DESCRIPTION
## What

A new, deliberately minimal artifact-generator skill: `prp-diagram`. Given a plan/PRD markdown path (or the most recent plan in the store when no argument is given), a single agent in a single pass writes a mermaid-only visual supplement — `<plan-basename>.diagrams.md` — next to the plan when it lives in the store, otherwise into `$PRP_DIR/plans/`.

## Design

- **Concept-prompt by design**: no phases, no validation loops, no subagents. One agent, one pass.
- **Strict content policy**: a title line, then per diagram one bold caption + one mermaid fence. No prose, no recommendations — diagrams supplement the plan, never editorialize it.
- **Diagram types follow the plan's content**: data model → erDiagram/classDiagram; architecture → flowchart (before/after subgraphs); flows → sequenceDiagram; lifecycle → stateDiagram-v2. Categories the plan doesn't support are skipped; ~40 nodes max per diagram.
- **Derived artifact**: overwrites on re-run; the plan stays the source of truth.
- **Canonical PRP store resolver** embedded byte-identically (drift guard in `sync_plugin.py --check` passes).
- `.html` output only on explicit request — `<pre class="mermaid">` blocks, no CDN/scripts; the consuming UI provides the renderer.

## Validation

- `python3 scripts/sync_plugin.py` + `--check` green; skill flowed into `plugins/prp-core/skills/` and the Codex render `.agents/skills/` automatically.
- Dogfooded end to end on `.claude/PRPs/plans/prp-home-reshape.md` → `~/.prp/prp-bb91a814/plans/prp-home-reshape.diagrams.md` (5 diagrams: 3 flowcharts, 1 sequenceDiagram, 1 stateDiagram-v2), each block hand-verified for mermaid validity.