### PR TITLE
feat(skills): prp-worklist — render the open work as a view worth looking at

### DIFF
--- a/plugins/prp-core/skills/prp-worklist/SKILL.md
+++ b/plugins/prp-core/skills/prp-worklist/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: prp-worklist
+description: Render the open work of a repository as something worth looking at, so the maintainer can see what to take next. Deliberate invocation only — /prp-worklist.
+argument-hint: "[repo] — defaults to the current repository"
+disable-model-invocation: true
+context: fork
+---
+
+# PRP Worklist
+
+**Incubating.** Deliberately underspecified. Make your own judgements, then say what you chose
+and why — the good choices get recorded and prescribed later. Do not wait for a spec that does
+not exist yet.
+
+Render the open issues and PRs of a repository as an artifact the maintainer can look at, and
+offer it. Not a list of everything — a view of **what to take next**.
+
+## The job
+
+A tracker sorts by number and shouts every label equally loudly. That is the tool's view, not
+the maintainer's. Produce the maintainer's view.
+
+Read the tracker with `gh`. Then decide what is worth showing and how to show it.
+
+## What this maintainer cares about
+
+Considerations, not fields to emit. Weigh them, drop the ones that do not apply, add what the
+repository makes obvious:
+
+- **Blocked on a decision, or takeable now.** The distinction he asks for most.
+- **Stale.** An issue whose premise has moved — the code it describes was deleted, the blocker
+  it waits on closed. Staleness should be visible, not discovered on starting the work.
+- **Near-duplicates.** Two issues that are one thing. Cheap to spot in a list, expensive to
+  find after both are filed.
+- **His, or someone else's.** Different obligations as a maintainer.
+- **Blast radius** rather than severity. What breaks, and for whom, if this is left.
+
+## Shape
+
+Yours to decide. Markdown or HTML, grouped or ranked, dense or spacious — whatever makes the
+answer to *"what do I take next"* obvious in a glance.
+
+Then **offer it rather than pasting it**: write the file to this project's `~/.prp/<key>/` store
+and print a link the operator can open. If a `helm-canvas` skill is available, follow it.
+
+## Report your choices
+
+End with a short note: what you grouped by, what you left out, what you could not tell from the
+tracker alone. That note is the point of this skill being loose — it is how the shape gets
+decided by evidence rather than up front.
+
+If something here got in your way, say that too.


### PR DESCRIPTION
A tracker sorts by number and shouts every label equally loudly. That is the tool's view, not the maintainer's. This renders the maintainer's view: **what to take next.**

## Deliberately light, deliberately underspecified

It names what the maintainer cares about as **considerations, not fields to emit** — blocked vs takeable, stale, near-duplicates, his vs someone else's, blast radius rather than severity — and hands the shape to the agent.

Then it asks the agent to report **what it grouped by, what it left out, and what it could not tell from the tracker alone.**

That reporting is the point. Operator's framing: *"if the agent does it well, we record what it did and prescribe what works later, so rather prompt some light direction rather than prescribe a workflow."* The shape gets decided by evidence instead of guessed at up front.

## Incubating, via the flag rather than a folder

`disable-model-invocation: true`. It installs and is discoverable everywhere — which is what lets it be tried across repos — but only ever fires when someone types `/prp-worklist`.

A half-shaped skill that fires on its own produces confident half-right output, which is worse than no skill because you cannot tell the two apart. **The flag is the incubation marker; a separate directory would have cost the discoverability that makes testing possible.** Worth noting the field is spelled identically in Claude Code and pi, so one file works in both.

`context: fork` follows Archon's own `triage` skill — reading forty issues should not cost the working context of whoever asked.

## Not this

`triage` (in Archon) applies labels. That is classification, and it is input to this. This is the view you read afterwards. Complementary, named differently on purpose.

## Composes later

Once helm's annotation work lands (helm #112), circling three issues and writing *"these are one thing"* becomes the return path — and with helm #110, what was dismissed goes back to the agent. Useful now as a static render; better later, with no rework.