### PR TITLE
fix(prp-issue): review the PR with the review agents, and act on what they find

### DIFF
--- a/.agents/skills/prp-issue/SKILL.md
+++ b/.agents/skills/prp-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prp-issue
-description: Investigate a GitHub issue and implement the fix - analyze codebase, create a plan, then code, PR, and self-review. Use when the user wants to investigate or triage a GitHub issue or bug report, fix an investigated issue, implement an issue fix, or invokes $prp-issue.
+description: Investigate a GitHub issue and implement the fix - analyze codebase, create a plan, then code, PR, review by the review agents, and act on their findings. Use when the user wants to investigate or triage a GitHub issue or bug report, fix an investigated issue, implement an issue fix, or invokes $prp-issue.
 ---
 
 > **Arguments:** `$ARGUMENTS` (and `$1`, `$2`, ...) refer to the arguments given when this skill was invoked. Take them from the user's request; if absent, infer them from the conversation.
@@ -19,7 +19,7 @@ PRP_DIR="${PRP_HOME:-$HOME/.prp}/${_name:-project}-$(printf %s "$_root" | git ha
 mkdir -p "$PRP_DIR"; [ -f "$PRP_DIR/project.json" ] || printf '{"path": "%s", "name": "%s"}\n' "$_root" "${_name:-project}" > "$PRP_DIR/project.json"
 ```
 
-Two-phase issue workflow: **investigate** an issue into an implementation artifact, then **fix** it from that artifact (code, PR, self-review).
+Two-phase issue workflow: **investigate** an issue into an implementation artifact, then **fix** it from that artifact (code, PR, agent review, act on findings).
 
 ---
 
@@ -40,5 +40,5 @@ Read the first token of `$ARGUMENTS` to choose the workflow. Everything after th
 ## Notes
 
 - `investigate` is read-mostly: it analyzes, writes an artifact under `$PRP_DIR/issues/`, and (for GitHub issues) posts a comment.
-- `fix` is **side-effecting**: it creates a branch, commits, opens a PR, and posts a self-review. Only run it once an investigation artifact exists.
+- `fix` is **side-effecting**: it creates a branch, commits, opens a PR, has the review agents review it, and pushes fixes for what they find. Only run it once an investigation artifact exists.
 - Typical flow: `prp-issue investigate <number>` → review the artifact → `prp-issue fix <number>`.

--- a/.agents/skills/prp-issue/workflows/fix.md
+++ b/.agents/skills/prp-issue/workflows/fix.md
@@ -15,7 +15,7 @@ Execute the implementation plan from `prp-issue investigate`:
 3. Implement the changes exactly as specified
 4. Run validation
 5. Create PR linked to issue
-6. Run self-review and post findings
+6. Have the PR reviewed by the review agents, then act on what they report
 7. Archive the artifact
 
 **Golden Rule**: Follow the artifact. If something seems wrong, validate it first - don't silently deviate.
@@ -450,79 +450,83 @@ PR_NUMBER=$(gh pr view --json number -q '.number')
 
 ---
 
-## Phase 8: REVIEW - Self Code Review
+## Phase 8: REVIEW - Review the PR, then act on it
 
-### 8.1 Run Self-Review Agents (in parallel)
+**Do not review your own diff.** You just wrote it, so you are the worst available reader of it —
+you will re-derive the reasoning that produced the bug instead of noticing the bug. Dispatch the
+review, then spend your turn on what it finds.
 
-Launch both agents as **two parallel subagents spawned in one step** so they run concurrently. Both are advisory and read the same diff — there is no reason to serialize them.
+### 8.1 Run the general review
 
-**code-reviewer** (spawn as the `code-reviewer` subagent):
-
-```
-Review the changes in this PR for issue #{number}.
-
-Focus on:
-1. Does the fix address the root cause from the investigation?
-2. Code quality - matches codebase patterns?
-3. Test coverage - are the new tests sufficient?
-4. Edge cases - are they handled?
-5. Security - any concerns?
-6. Potential bugs - anything that could break?
-
-Review only the diff, not the entire codebase.
-```
-
-**code-simplifier** (spawn as the `code-simplifier` subagent):
+Invoke the review skill against the PR you just opened:
 
 ```
-Identify simplification opportunities in the changes for issue #{number}.
-Focus only on the diff. Prefer explicit over clever; no nested ternaries.
-Report findings with before/after suggestions. Advisory only — do not modify files or commit.
+$prp-review {pr-number} --agents code simplify
 ```
 
-### 8.2 Post Review to PR
+That is the whole of this step. It dispatches the reviewers, writes
+`$PRP_DIR/reviews/pr-{pr-number}-review.md`, and posts the summary to the PR.
+
+- **Two agents, named on purpose — not `all`.** `code` and `simplify` are `code-reviewer`
+  and `code-simplifier`. This workflow ships one artifact-sized fix, and the full aspect
+  stack costs more than that fix is worth. Reach for `--agents all` by hand on a PR that earns it.
+- **Do not post your own review comment.** The review skill already posted one, and a second
+  summary written by the author of the code is exactly the self-review this phase exists to avoid.
+
+### 8.2 Act on the findings
+
+A review nobody acts on is a comment. Work the report:
+
+- **Critical and Important — fix them**, unless the finding is wrong. If it is wrong, say why in
+  8.3; do not fix it silently and do not ignore it silently.
+- **Suggestions — judge each one, and expect to decline some.** Apply what makes the change simpler
+  or more correct. Decline anything that adds a capability nobody asked for (YAGNI), generalizes
+  for a second caller that does not exist, adds a layer, an option, or a config knob to a thing
+  with one use, or trades a plain implementation for a clever one.
+- **Out of scope is a real answer.** A finding about code this PR did not touch belongs in an
+  issue, not in this diff. File it or name it; do not widen the PR to swallow it.
+
+When the finding is genuine but the proposed remedy is over-built, fix the finding the small way
+rather than declining it.
+
+After applying anything: **re-run Phase 6's validation**, then commit and push. A review fix that
+breaks the gate is worse than the finding it addressed.
 
 ```bash
-gh pr comment --body "$(cat <<'EOF'
-## 🔍 Automated Code Review
+git add -A
+git commit -m "fix(scope): address review findings on #{number}"
+git push
+```
 
-### Summary
+### 8.3 Say what you did with it
 
-{1-2 sentence assessment}
+One short comment on the PR, so the declines are visible rather than silent:
 
-### Findings
+```bash
+gh pr comment {pr-number} --body "$(cat <<'EOF'
+### Review findings — applied
 
-#### ✅ Strengths
-- {Good thing 1}
-- {Good thing 2}
+- `{file}:{line}` — {what changed}
 
-#### ⚠️ Suggestions (non-blocking)
-- `{file}:{line}` - {suggestion}
-- {other suggestions}
+### Declined
 
-#### 🧹 Simplification (from code-simplifier)
-- `{file}:{line}` - {simplification, or "No simplifications identified"}
+- {finding} — {why: YAGNI / out of scope / disagreed, and on what grounds}
 
-#### 🔒 Security
-- {Any concerns or "No security concerns identified"}
-
-### Checklist
-
-- [x] Fix addresses root cause from investigation
-- [x] Code follows codebase patterns
-- [x] Tests cover the change
-- [x] No obvious bugs introduced
-
----
-*Self-reviewed by Claude • Ready for human review*
+Validation re-run after the changes: {result}
 EOF
 )"
 ```
 
+If nothing was declined, drop that section rather than writing "none" — and if nothing needed
+fixing at all, say that in one line instead of posting the template.
+
 **PHASE_8_CHECKPOINT:**
 
-- [ ] Code review + simplification completed (run in parallel)
-- [ ] Review posted to PR
+- [ ] `prp-review --agents` dispatched against the PR; report written and posted by it
+- [ ] Critical and Important findings fixed, or explicitly rejected with a reason
+- [ ] Suggestions judged individually; over-engineered ones declined
+- [ ] Validation re-run and green after any change; commits pushed
+- [ ] Applied/declined comment posted
 
 ---
 
@@ -571,9 +575,9 @@ Do **not** stage, commit, or push the archive; it is stored outside the reposito
 | Tests      | ✅ Pass |
 | Lint       | ✅ Pass |
 
-### Self-Review
+### Review
 
-{Summary of review findings}
+{What the review found, what was applied, what was declined and why}
 
 ### Artifact
 
@@ -633,6 +637,7 @@ Do **not** stage, commit, or push the archive; it is stored outside the reposito
 - **PLAN_EXECUTED**: All artifact steps completed
 - **VALIDATION_PASSED**: All checks green
 - **PR_CREATED**: PR exists and linked to issue
-- **REVIEW_POSTED**: Self-review comment on PR
+- **REVIEWED_BY_AGENTS**: `prp-review --agents` run against the PR, its report posted
+- **FINDINGS_ACTIONED**: Every Critical/Important fixed or rejected with a reason; declines stated on the PR
 - **ARTIFACT_ARCHIVED**: Moved to completed folder
 - **AUDIT_TRAIL**: GitHub comment and PRP-store artifact history

--- a/.agents/skills/prp-review/workflows/agents.md
+++ b/.agents/skills/prp-review/workflows/agents.md
@@ -67,7 +67,9 @@ Run in two steps: **decide which agents apply, then dispatch them in parallel.**
 
 ### Step 1 — Decide which agents apply
 
-Using the Aspect Selection Logic above (and any aspects passed in `$ARGUMENTS`), build the final list of agents to run:
+**If `$ARGUMENTS` names aspects, they ARE the list — run exactly those and nothing else.** `--agents code simplify` means two agents, not two plus whatever the diff would otherwise have attracted. A caller naming aspects has already decided how much review this PR is worth, and quietly adding to their list spends their tokens on a decision they did not make. `all` is the only aspect that means "apply the logic below".
+
+Otherwise — no aspects named, or `all` — use the Aspect Selection Logic above to build the list:
 
 - Always include `code-reviewer`.
 - Add `docs-impact-agent` unless the PR is trivial (see skip rules).

--- a/.agents/skills/prp-worklist/SKILL.md
+++ b/.agents/skills/prp-worklist/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: prp-worklist
+description: Render the open work of a repository as something worth looking at, so the maintainer can see what to take next. Deliberate invocation only — $prp-worklist.
+disable-model-invocation: true
+context: fork
+---
+
+# PRP Worklist
+
+**Incubating.** Deliberately underspecified. Make your own judgements, then say what you chose
+and why — the good choices get recorded and prescribed later. Do not wait for a spec that does
+not exist yet.
+
+Render the open issues and PRs of a repository as an artifact the maintainer can look at, and
+offer it. Not a list of everything — a view of **what to take next**.
+
+## The job
+
+A tracker sorts by number and shouts every label equally loudly. That is the tool's view, not
+the maintainer's. Produce the maintainer's view.
+
+Read the tracker with `gh`. Then decide what is worth showing and how to show it.
+
+## What this maintainer cares about
+
+Considerations, not fields to emit. Weigh them, drop the ones that do not apply, add what the
+repository makes obvious:
+
+- **Blocked on a decision, or takeable now.** The distinction he asks for most.
+- **Stale.** An issue whose premise has moved — the code it describes was deleted, the blocker
+  it waits on closed. Staleness should be visible, not discovered on starting the work.
+- **Near-duplicates.** Two issues that are one thing. Cheap to spot in a list, expensive to
+  find after both are filed.
+- **His, or someone else's.** Different obligations as a maintainer.
+- **Blast radius** rather than severity. What breaks, and for whom, if this is left.
+
+## Shape
+
+Yours to decide. Markdown or HTML, grouped or ranked, dense or spacious — whatever makes the
+answer to *"what do I take next"* obvious in a glance.
+
+Then **offer it rather than pasting it**: write the file to this project's `~/.prp/<key>/` store
+and print a link the operator can open. If a `helm-canvas` skill is available, follow it.
+
+## Report your choices
+
+End with a short note: what you grouped by, what you left out, what you could not tell from the
+tracker alone. That note is the point of this skill being loose — it is how the shape gets
+decided by evidence rather than up front.
+
+If something here got in your way, say that too.

--- a/.claude/skills/prp-issue/SKILL.md
+++ b/.claude/skills/prp-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prp-issue
-description: Investigate a GitHub issue and implement the fix - analyze codebase, create a plan, then code, PR, and self-review. Use when the user wants to investigate or triage a GitHub issue or bug report, fix an investigated issue, implement an issue fix, or invokes /prp-issue.
+description: Investigate a GitHub issue and implement the fix - analyze codebase, create a plan, then code, PR, review by the review agents, and act on their findings. Use when the user wants to investigate or triage a GitHub issue or bug report, fix an investigated issue, implement an issue fix, or invokes /prp-issue.
 argument-hint: "investigate <issue-number|url|\"description\"> | fix <issue-number|artifact-path> [--base <branch>]"
 ---
 
@@ -18,7 +18,7 @@ PRP_DIR="${PRP_HOME:-$HOME/.prp}/${_name:-project}-$(printf %s "$_root" | git ha
 mkdir -p "$PRP_DIR"; [ -f "$PRP_DIR/project.json" ] || printf '{"path": "%s", "name": "%s"}\n' "$_root" "${_name:-project}" > "$PRP_DIR/project.json"
 ```
 
-Two-phase issue workflow: **investigate** an issue into an implementation artifact, then **fix** it from that artifact (code, PR, self-review).
+Two-phase issue workflow: **investigate** an issue into an implementation artifact, then **fix** it from that artifact (code, PR, agent review, act on findings).
 
 ---
 
@@ -39,5 +39,5 @@ Read the first token of `$ARGUMENTS` to choose the workflow. Everything after th
 ## Notes
 
 - `investigate` is read-mostly: it analyzes, writes an artifact under `$PRP_DIR/issues/`, and (for GitHub issues) posts a comment.
-- `fix` is **side-effecting**: it creates a branch, commits, opens a PR, and posts a self-review. Only run it once an investigation artifact exists.
+- `fix` is **side-effecting**: it creates a branch, commits, opens a PR, has the review agents review it, and pushes fixes for what they find. Only run it once an investigation artifact exists.
 - Typical flow: `prp-issue investigate <number>` → review the artifact → `prp-issue fix <number>`.

--- a/.claude/skills/prp-issue/workflows/fix.md
+++ b/.claude/skills/prp-issue/workflows/fix.md
@@ -13,7 +13,7 @@ Execute the implementation plan from `prp-issue investigate`:
 3. Implement the changes exactly as specified
 4. Run validation
 5. Create PR linked to issue
-6. Run self-review and post findings
+6. Have the PR reviewed by the review agents, then act on what they report
 7. Archive the artifact
 
 **Golden Rule**: Follow the artifact. If something seems wrong, validate it first - don't silently deviate.
@@ -448,79 +448,83 @@ PR_NUMBER=$(gh pr view --json number -q '.number')
 
 ---
 
-## Phase 8: REVIEW - Self Code Review
+## Phase 8: REVIEW - Review the PR, then act on it
 
-### 8.1 Run Self-Review Agents (in parallel)
+**Do not review your own diff.** You just wrote it, so you are the worst available reader of it —
+you will re-derive the reasoning that produced the bug instead of noticing the bug. Dispatch the
+review, then spend your turn on what it finds.
 
-Launch both agents in a **single message with two Task tool calls** so they run concurrently. Both are advisory and read the same diff — there is no reason to serialize them.
+### 8.1 Run the general review
 
-**prp-core:code-reviewer** (subagent_type="prp-core:code-reviewer"):
-
-```
-Review the changes in this PR for issue #{number}.
-
-Focus on:
-1. Does the fix address the root cause from the investigation?
-2. Code quality - matches codebase patterns?
-3. Test coverage - are the new tests sufficient?
-4. Edge cases - are they handled?
-5. Security - any concerns?
-6. Potential bugs - anything that could break?
-
-Review only the diff, not the entire codebase.
-```
-
-**prp-core:code-simplifier** (subagent_type="prp-core:code-simplifier"):
+Invoke the review skill against the PR you just opened:
 
 ```
-Identify simplification opportunities in the changes for issue #{number}.
-Focus only on the diff. Prefer explicit over clever; no nested ternaries.
-Report findings with before/after suggestions. Advisory only — do not modify files or commit.
+/prp-core:prp-review {pr-number} --agents code simplify
 ```
 
-### 8.2 Post Review to PR
+That is the whole of this step. It dispatches the reviewers, writes
+`$PRP_DIR/reviews/pr-{pr-number}-review.md`, and posts the summary to the PR.
+
+- **Two agents, named on purpose — not `all`.** `code` and `simplify` are `prp-core:code-reviewer`
+  and `prp-core:code-simplifier`. This workflow ships one artifact-sized fix, and the full aspect
+  stack costs more than that fix is worth. Reach for `--agents all` by hand on a PR that earns it.
+- **Do not post your own review comment.** The review skill already posted one, and a second
+  summary written by the author of the code is exactly the self-review this phase exists to avoid.
+
+### 8.2 Act on the findings
+
+A review nobody acts on is a comment. Work the report:
+
+- **Critical and Important — fix them**, unless the finding is wrong. If it is wrong, say why in
+  8.3; do not fix it silently and do not ignore it silently.
+- **Suggestions — judge each one, and expect to decline some.** Apply what makes the change simpler
+  or more correct. Decline anything that adds a capability nobody asked for (YAGNI), generalizes
+  for a second caller that does not exist, adds a layer, an option, or a config knob to a thing
+  with one use, or trades a plain implementation for a clever one.
+- **Out of scope is a real answer.** A finding about code this PR did not touch belongs in an
+  issue, not in this diff. File it or name it; do not widen the PR to swallow it.
+
+When the finding is genuine but the proposed remedy is over-built, fix the finding the small way
+rather than declining it.
+
+After applying anything: **re-run Phase 6's validation**, then commit and push. A review fix that
+breaks the gate is worse than the finding it addressed.
 
 ```bash
-gh pr comment --body "$(cat <<'EOF'
-## 🔍 Automated Code Review
+git add -A
+git commit -m "fix(scope): address review findings on #{number}"
+git push
+```
 
-### Summary
+### 8.3 Say what you did with it
 
-{1-2 sentence assessment}
+One short comment on the PR, so the declines are visible rather than silent:
 
-### Findings
+```bash
+gh pr comment {pr-number} --body "$(cat <<'EOF'
+### Review findings — applied
 
-#### ✅ Strengths
-- {Good thing 1}
-- {Good thing 2}
+- `{file}:{line}` — {what changed}
 
-#### ⚠️ Suggestions (non-blocking)
-- `{file}:{line}` - {suggestion}
-- {other suggestions}
+### Declined
 
-#### 🧹 Simplification (from prp-core:code-simplifier)
-- `{file}:{line}` - {simplification, or "No simplifications identified"}
+- {finding} — {why: YAGNI / out of scope / disagreed, and on what grounds}
 
-#### 🔒 Security
-- {Any concerns or "No security concerns identified"}
-
-### Checklist
-
-- [x] Fix addresses root cause from investigation
-- [x] Code follows codebase patterns
-- [x] Tests cover the change
-- [x] No obvious bugs introduced
-
----
-*Self-reviewed by Claude • Ready for human review*
+Validation re-run after the changes: {result}
 EOF
 )"
 ```
 
+If nothing was declined, drop that section rather than writing "none" — and if nothing needed
+fixing at all, say that in one line instead of posting the template.
+
 **PHASE_8_CHECKPOINT:**
 
-- [ ] Code review + simplification completed (run in parallel)
-- [ ] Review posted to PR
+- [ ] `prp-review --agents` dispatched against the PR; report written and posted by it
+- [ ] Critical and Important findings fixed, or explicitly rejected with a reason
+- [ ] Suggestions judged individually; over-engineered ones declined
+- [ ] Validation re-run and green after any change; commits pushed
+- [ ] Applied/declined comment posted
 
 ---
 
@@ -569,9 +573,9 @@ Do **not** stage, commit, or push the archive; it is stored outside the reposito
 | Tests      | ✅ Pass |
 | Lint       | ✅ Pass |
 
-### Self-Review
+### Review
 
-{Summary of review findings}
+{What the review found, what was applied, what was declined and why}
 
 ### Artifact
 
@@ -631,6 +635,7 @@ Do **not** stage, commit, or push the archive; it is stored outside the reposito
 - **PLAN_EXECUTED**: All artifact steps completed
 - **VALIDATION_PASSED**: All checks green
 - **PR_CREATED**: PR exists and linked to issue
-- **REVIEW_POSTED**: Self-review comment on PR
+- **REVIEWED_BY_AGENTS**: `prp-review --agents` run against the PR, its report posted
+- **FINDINGS_ACTIONED**: Every Critical/Important fixed or rejected with a reason; declines stated on the PR
 - **ARTIFACT_ARCHIVED**: Moved to completed folder
 - **AUDIT_TRAIL**: GitHub comment and PRP-store artifact history

--- a/.claude/skills/prp-review/workflows/agents.md
+++ b/.claude/skills/prp-review/workflows/agents.md
@@ -65,7 +65,9 @@ Run in two steps: **decide which agents apply, then dispatch them in parallel.**
 
 ### Step 1 — Decide which agents apply
 
-Using the Aspect Selection Logic above (and any aspects passed in `$ARGUMENTS`), build the final list of agents to run:
+**If `$ARGUMENTS` names aspects, they ARE the list — run exactly those and nothing else.** `--agents code simplify` means two agents, not two plus whatever the diff would otherwise have attracted. A caller naming aspects has already decided how much review this PR is worth, and quietly adding to their list spends their tokens on a decision they did not make. `all` is the only aspect that means "apply the logic below".
+
+Otherwise — no aspects named, or `all` — use the Aspect Selection Logic above to build the list:
 
 - Always include `prp-core:code-reviewer`.
 - Add `prp-core:docs-impact-agent` unless the PR is trivial (see skip rules).

--- a/.claude/skills/prp-worklist/SKILL.md
+++ b/.claude/skills/prp-worklist/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: prp-worklist
+description: Render the open work of a repository as something worth looking at, so the maintainer can see what to take next. Deliberate invocation only — /prp-worklist.
+argument-hint: "[repo] — defaults to the current repository"
+disable-model-invocation: true
+context: fork
+---
+
+# PRP Worklist
+
+**Incubating.** Deliberately underspecified. Make your own judgements, then say what you chose
+and why — the good choices get recorded and prescribed later. Do not wait for a spec that does
+not exist yet.
+
+Render the open issues and PRs of a repository as an artifact the maintainer can look at, and
+offer it. Not a list of everything — a view of **what to take next**.
+
+## The job
+
+A tracker sorts by number and shouts every label equally loudly. That is the tool's view, not
+the maintainer's. Produce the maintainer's view.
+
+Read the tracker with `gh`. Then decide what is worth showing and how to show it.
+
+## What this maintainer cares about
+
+Considerations, not fields to emit. Weigh them, drop the ones that do not apply, add what the
+repository makes obvious:
+
+- **Blocked on a decision, or takeable now.** The distinction he asks for most.
+- **Stale.** An issue whose premise has moved — the code it describes was deleted, the blocker
+  it waits on closed. Staleness should be visible, not discovered on starting the work.
+- **Near-duplicates.** Two issues that are one thing. Cheap to spot in a list, expensive to
+  find after both are filed.
+- **His, or someone else's.** Different obligations as a maintainer.
+- **Blast radius** rather than severity. What breaks, and for whom, if this is left.
+
+## Shape
+
+Yours to decide. Markdown or HTML, grouped or ranked, dense or spacious — whatever makes the
+answer to *"what do I take next"* obvious in a glance.
+
+Then **offer it rather than pasting it**: write the file to this project's `~/.prp/<key>/` store
+and print a link the operator can open. If a `helm-canvas` skill is available, follow it.
+
+## Report your choices
+
+End with a short note: what you grouped by, what you left out, what you could not tell from the
+tracker alone. That note is the point of this skill being loose — it is how the shape gets
+decided by evidence rather than up front.
+
+If something here got in your way, say that too.

--- a/plugins/prp-core/skills/prp-issue/SKILL.md
+++ b/plugins/prp-core/skills/prp-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prp-issue
-description: Investigate a GitHub issue and implement the fix - analyze codebase, create a plan, then code, PR, and self-review. Use when the user wants to investigate or triage a GitHub issue or bug report, fix an investigated issue, implement an issue fix, or invokes /prp-issue.
+description: Investigate a GitHub issue and implement the fix - analyze codebase, create a plan, then code, PR, review by the review agents, and act on their findings. Use when the user wants to investigate or triage a GitHub issue or bug report, fix an investigated issue, implement an issue fix, or invokes /prp-issue.
 argument-hint: "investigate <issue-number|url|\"description\"> | fix <issue-number|artifact-path> [--base <branch>]"
 ---
 
@@ -18,7 +18,7 @@ PRP_DIR="${PRP_HOME:-$HOME/.prp}/${_name:-project}-$(printf %s "$_root" | git ha
 mkdir -p "$PRP_DIR"; [ -f "$PRP_DIR/project.json" ] || printf '{"path": "%s", "name": "%s"}\n' "$_root" "${_name:-project}" > "$PRP_DIR/project.json"
 ```
 
-Two-phase issue workflow: **investigate** an issue into an implementation artifact, then **fix** it from that artifact (code, PR, self-review).
+Two-phase issue workflow: **investigate** an issue into an implementation artifact, then **fix** it from that artifact (code, PR, agent review, act on findings).
 
 ---
 
@@ -39,5 +39,5 @@ Read the first token of `$ARGUMENTS` to choose the workflow. Everything after th
 ## Notes
 
 - `investigate` is read-mostly: it analyzes, writes an artifact under `$PRP_DIR/issues/`, and (for GitHub issues) posts a comment.
-- `fix` is **side-effecting**: it creates a branch, commits, opens a PR, and posts a self-review. Only run it once an investigation artifact exists.
+- `fix` is **side-effecting**: it creates a branch, commits, opens a PR, has the review agents review it, and pushes fixes for what they find. Only run it once an investigation artifact exists.
 - Typical flow: `prp-issue investigate <number>` → review the artifact → `prp-issue fix <number>`.

--- a/plugins/prp-core/skills/prp-issue/workflows/fix.md
+++ b/plugins/prp-core/skills/prp-issue/workflows/fix.md
@@ -13,7 +13,7 @@ Execute the implementation plan from `prp-issue investigate`:
 3. Implement the changes exactly as specified
 4. Run validation
 5. Create PR linked to issue
-6. Run self-review and post findings
+6. Have the PR reviewed by the review agents, then act on what they report
 7. Archive the artifact
 
 **Golden Rule**: Follow the artifact. If something seems wrong, validate it first - don't silently deviate.
@@ -448,79 +448,83 @@ PR_NUMBER=$(gh pr view --json number -q '.number')
 
 ---
 
-## Phase 8: REVIEW - Self Code Review
+## Phase 8: REVIEW - Review the PR, then act on it
 
-### 8.1 Run Self-Review Agents (in parallel)
+**Do not review your own diff.** You just wrote it, so you are the worst available reader of it —
+you will re-derive the reasoning that produced the bug instead of noticing the bug. Dispatch the
+review, then spend your turn on what it finds.
 
-Launch both agents in a **single message with two Task tool calls** so they run concurrently. Both are advisory and read the same diff — there is no reason to serialize them.
+### 8.1 Run the general review
 
-**prp-core:code-reviewer** (subagent_type="prp-core:code-reviewer"):
-
-```
-Review the changes in this PR for issue #{number}.
-
-Focus on:
-1. Does the fix address the root cause from the investigation?
-2. Code quality - matches codebase patterns?
-3. Test coverage - are the new tests sufficient?
-4. Edge cases - are they handled?
-5. Security - any concerns?
-6. Potential bugs - anything that could break?
-
-Review only the diff, not the entire codebase.
-```
-
-**prp-core:code-simplifier** (subagent_type="prp-core:code-simplifier"):
+Invoke the review skill against the PR you just opened:
 
 ```
-Identify simplification opportunities in the changes for issue #{number}.
-Focus only on the diff. Prefer explicit over clever; no nested ternaries.
-Report findings with before/after suggestions. Advisory only — do not modify files or commit.
+/prp-core:prp-review {pr-number} --agents code simplify
 ```
 
-### 8.2 Post Review to PR
+That is the whole of this step. It dispatches the reviewers, writes
+`$PRP_DIR/reviews/pr-{pr-number}-review.md`, and posts the summary to the PR.
+
+- **Two agents, named on purpose — not `all`.** `code` and `simplify` are `prp-core:code-reviewer`
+  and `prp-core:code-simplifier`. This workflow ships one artifact-sized fix, and the full aspect
+  stack costs more than that fix is worth. Reach for `--agents all` by hand on a PR that earns it.
+- **Do not post your own review comment.** The review skill already posted one, and a second
+  summary written by the author of the code is exactly the self-review this phase exists to avoid.
+
+### 8.2 Act on the findings
+
+A review nobody acts on is a comment. Work the report:
+
+- **Critical and Important — fix them**, unless the finding is wrong. If it is wrong, say why in
+  8.3; do not fix it silently and do not ignore it silently.
+- **Suggestions — judge each one, and expect to decline some.** Apply what makes the change simpler
+  or more correct. Decline anything that adds a capability nobody asked for (YAGNI), generalizes
+  for a second caller that does not exist, adds a layer, an option, or a config knob to a thing
+  with one use, or trades a plain implementation for a clever one.
+- **Out of scope is a real answer.** A finding about code this PR did not touch belongs in an
+  issue, not in this diff. File it or name it; do not widen the PR to swallow it.
+
+When the finding is genuine but the proposed remedy is over-built, fix the finding the small way
+rather than declining it.
+
+After applying anything: **re-run Phase 6's validation**, then commit and push. A review fix that
+breaks the gate is worse than the finding it addressed.
 
 ```bash
-gh pr comment --body "$(cat <<'EOF'
-## 🔍 Automated Code Review
+git add -A
+git commit -m "fix(scope): address review findings on #{number}"
+git push
+```
 
-### Summary
+### 8.3 Say what you did with it
 
-{1-2 sentence assessment}
+One short comment on the PR, so the declines are visible rather than silent:
 
-### Findings
+```bash
+gh pr comment {pr-number} --body "$(cat <<'EOF'
+### Review findings — applied
 
-#### ✅ Strengths
-- {Good thing 1}
-- {Good thing 2}
+- `{file}:{line}` — {what changed}
 
-#### ⚠️ Suggestions (non-blocking)
-- `{file}:{line}` - {suggestion}
-- {other suggestions}
+### Declined
 
-#### 🧹 Simplification (from prp-core:code-simplifier)
-- `{file}:{line}` - {simplification, or "No simplifications identified"}
+- {finding} — {why: YAGNI / out of scope / disagreed, and on what grounds}
 
-#### 🔒 Security
-- {Any concerns or "No security concerns identified"}
-
-### Checklist
-
-- [x] Fix addresses root cause from investigation
-- [x] Code follows codebase patterns
-- [x] Tests cover the change
-- [x] No obvious bugs introduced
-
----
-*Self-reviewed by Claude • Ready for human review*
+Validation re-run after the changes: {result}
 EOF
 )"
 ```
 
+If nothing was declined, drop that section rather than writing "none" — and if nothing needed
+fixing at all, say that in one line instead of posting the template.
+
 **PHASE_8_CHECKPOINT:**
 
-- [ ] Code review + simplification completed (run in parallel)
-- [ ] Review posted to PR
+- [ ] `prp-review --agents` dispatched against the PR; report written and posted by it
+- [ ] Critical and Important findings fixed, or explicitly rejected with a reason
+- [ ] Suggestions judged individually; over-engineered ones declined
+- [ ] Validation re-run and green after any change; commits pushed
+- [ ] Applied/declined comment posted
 
 ---
 
@@ -569,9 +573,9 @@ Do **not** stage, commit, or push the archive; it is stored outside the reposito
 | Tests      | ✅ Pass |
 | Lint       | ✅ Pass |
 
-### Self-Review
+### Review
 
-{Summary of review findings}
+{What the review found, what was applied, what was declined and why}
 
 ### Artifact
 
@@ -631,6 +635,7 @@ Do **not** stage, commit, or push the archive; it is stored outside the reposito
 - **PLAN_EXECUTED**: All artifact steps completed
 - **VALIDATION_PASSED**: All checks green
 - **PR_CREATED**: PR exists and linked to issue
-- **REVIEW_POSTED**: Self-review comment on PR
+- **REVIEWED_BY_AGENTS**: `prp-review --agents` run against the PR, its report posted
+- **FINDINGS_ACTIONED**: Every Critical/Important fixed or rejected with a reason; declines stated on the PR
 - **ARTIFACT_ARCHIVED**: Moved to completed folder
 - **AUDIT_TRAIL**: GitHub comment and PRP-store artifact history

--- a/plugins/prp-core/skills/prp-review/workflows/agents.md
+++ b/plugins/prp-core/skills/prp-review/workflows/agents.md
@@ -65,7 +65,9 @@ Run in two steps: **decide which agents apply, then dispatch them in parallel.**
 
 ### Step 1 — Decide which agents apply
 
-Using the Aspect Selection Logic above (and any aspects passed in `$ARGUMENTS`), build the final list of agents to run:
+**If `$ARGUMENTS` names aspects, they ARE the list — run exactly those and nothing else.** `--agents code simplify` means two agents, not two plus whatever the diff would otherwise have attracted. A caller naming aspects has already decided how much review this PR is worth, and quietly adding to their list spends their tokens on a decision they did not make. `all` is the only aspect that means "apply the logic below".
+
+Otherwise — no aspects named, or `all` — use the Aspect Selection Logic above to build the list:
 
 - Always include `prp-core:code-reviewer`.
 - Add `prp-core:docs-impact-agent` unless the PR is trivial (see skip rules).

--- a/profiles/kild/skills/prp-review/workflows/agents.md
+++ b/profiles/kild/skills/prp-review/workflows/agents.md
@@ -69,7 +69,9 @@ Run in two steps: **decide which agents apply, then dispatch them in parallel.**
 
 ### Step 1 — Decide which agents apply
 
-Using the Aspect Selection Logic above (and any aspects passed in `$ARGUMENTS`), build the final list of agents to run:
+**If `$ARGUMENTS` names aspects, they ARE the list — run exactly those and nothing else.** `--agents code simplify` means two agents, not two plus whatever the diff would otherwise have attracted. A caller naming aspects has already decided how much review this PR is worth, and quietly adding to their list spends their tokens on a decision they did not make. `all` is the only aspect that means "apply the logic below".
+
+Otherwise — no aspects named, or `all` — use the Aspect Selection Logic above to build the list:
 
 - Always include `code-reviewer`.
 - Add `docs-impact-agent` unless the PR is trivial (see skip rules).


### PR DESCRIPTION
Found in a live run: `prp-issue fix` reviewed its own diff instead of dispatching the review.

## Why it did that

Phase 8 was titled **"Self Code Review"**, its step was **"Run Self-Review Agents"**, the report
section was **"Self-Review"**, and it signed off `*Self-reviewed by Claude*`. One line in the middle
said to dispatch two subagents; eight around it said to review your own work. Read after 450 lines
of implementing, the heading wins.

## What it does now

**8.1 — invoke `/prp-core:prp-review {pr} --agents code simplify`, and stop there.**

Same two reviewers as before — `code-reviewer` and `code-simplifier` — deliberately. This workflow
ships one artifact-sized fix, and the full aspect stack costs more than that fix is worth;
`--agents all` stays a thing you reach for by hand on a PR that earns it. What changes is **who
dispatches them**: the review skill, not the author of the diff. It also writes
`$PRP_DIR/reviews/pr-N-review.md` and posts it, so the hand-rolled `gh pr comment` template is gone
— a second summary written by the author of the code is the exact thing being removed.

**Naming aspects only works if it actually scopes the roster, and it didn't.** `prp-review`'s Step 1
read "always include code-reviewer, add docs-impact unless trivial, add change-based specialists
based on what the diff touches" with no regard for what the caller asked for — so `--agents code
simplify` would have quietly run the whole stack, and the skill's own documented example
(`# Only code and docs review`) was false. Named aspects are now **the** list; `all` is the one
aspect that means "apply the selection logic". A caller naming aspects has already decided how much
review the PR is worth, and adding to their list spends their tokens on a decision they didn't make.

**8.2 — act on the findings.** This was missing entirely; the old phase posted a comment and went
straight to archive.

- Critical and Important: fix, or explicitly reject with a reason. Not silently either way.
- Suggestions: judged one at a time, and **expected to be declined** when they add a capability
  nobody asked for, generalize for a second caller that does not exist, add a layer/option/knob to
  a thing with one use, or trade a plain implementation for a clever one.
- When the finding is genuine but the proposed remedy is over-built, fix the finding the small way
  rather than declining it.
- Out of scope is a real answer — it becomes an issue, not a wider diff.
- Re-run validation before pushing. A review fix that breaks the gate is worse than the finding.

**8.3 — say what was done with it**, so declines are visible rather than silent.

`SKILL.md`'s description, the mission list, the report template and the success criteria all said
"self-review" too; all updated. The one surviving mention is the sentence explaining what the phase
now avoids.

## Second commit — unrelated, and it bit during this change

`sync_plugin.py` deleted `plugins/prp-core/skills/prp-worklist/SKILL.md` when I regenerated.

e0f4d28 added that skill under `plugins/prp-core/skills/` **only**. That directory is generated from
`.claude/skills/`, so the skill had no source — `--check` has been failing since, and the next
person to run a sync deletes it. Restored as a real source under `.claude/skills/prp-worklist/`,
which regenerates the plugin copy **byte-identical** to what was committed and adds the Codex render
it never had. Contents untouched.

## Validation

- `python3 scripts/sync_plugin.py --check` — all targets in sync (was failing on `development` before this).
- `python3 -m py_compile prp_loop.py` — ok.
- Codex render verified by hand: `/prp-core:prp-review …` correctly becomes `$prp-review …`.
- All four renders carry the same roster: `.claude/`, `.agents/`, `plugins/prp-core/`, `profiles/kild/`.
