### PR TITLE
fix(prp-issue): "investigate and fix" must read fix.md, not improvise it

### DIFF
--- a/.agents/skills/prp-issue/SKILL.md
+++ b/.agents/skills/prp-issue/SKILL.md
@@ -31,9 +31,19 @@ Read the first token of `$ARGUMENTS` to choose the workflow. Everything after th
 |-------------|----------|-------------|
 | `investigate` | `workflows/investigate.md` | issue number / URL / free-form description |
 | `fix` | `workflows/fix.md` | issue number / artifact path (`+ optional --base <branch>`) |
+| **both verbs** — `investigate and fix`, `investigate then fix` | `workflows/investigate.md`, **then** `workflows/fix.md` | the issue; the artifact the first phase writes is the second phase's input |
 | _no verb_ (a bare issue number, URL, or description) | `workflows/investigate.md` | the whole argument — investigation is the entry point; you investigate before you fix |
 
-**Action**: strip the leading verb (if present), then follow the matching workflow file end-to-end. Do not blend the two — pick one and execute it fully.
+**Action**: strip the verb(s), then follow each matching workflow file end-to-end, in the order above.
+
+**Read the workflow file for every phase you run — including the second one.** Both phases asked for
+means both files read. Finishing an investigation leaves you holding a plan and feeling ready to
+implement it, and implementing from that feeling is the failure this line exists to stop: `fix.md`
+carries the branch discipline, the validation gate, the PR, the agent review and the archive, and an
+agent that never opened it silently does none of them. It has happened.
+
+**Do not blend them.** Sequential, each run to its end — not interleaved, and not one phase
+improvising the other's steps from memory.
 
 ---
 

--- a/.agents/skills/prp-issue/workflows/investigate.md
+++ b/.agents/skills/prp-issue/workflows/investigate.md
@@ -16,6 +16,9 @@ Investigate the issue/problem and produce a comprehensive implementation plan th
 
 **Golden Rule**: The artifact you produce IS the specification. The implementing agent should be able to work from it without asking questions.
 
+**If the operator asked to investigate *and* fix, this file is only your first half** — see "If the
+invocation also asked for the fix" below before you stop or start editing code.
+
 ---
 
 ## Phase 1: PARSE - Understand Input
@@ -576,6 +579,28 @@ Run `$prp-issue fix {number}` to execute the plan.
 
 ---
 
+## If the invocation also asked for the fix
+
+Investigation ends here **only** when the operator asked to investigate. If they asked for both —
+`investigate and fix`, `investigate this and fix it`, or any phrasing carrying both — you are half
+done, and the next thing you do is:
+
+**Read `workflows/fix.md` and execute it end-to-end, with the artifact you just wrote as its input.**
+
+Read the file. Do not implement from what is in your head right now.
+
+You are holding a fresh, detailed, correct plan, which is exactly what makes this the moment the
+step gets skipped: implementing feels like the obvious next move and the file feels redundant. It
+is not. `fix.md` is seven phases you have not seen — artifact drift check, branch discipline, the
+validation gate, commit and PR, review by the review agents and acting on their findings, and the
+archive. An agent that goes straight to editing performs none of them and produces a plausible diff
+with no PR, no review and no artifact archived. That is a real run, not a hypothetical.
+
+The "Next Step" line above is what you print for the operator when they asked only to investigate.
+It is not permission to stop when they asked for more.
+
+---
+
 ## Handling Edge Cases
 
 ### Issue is already closed
@@ -610,3 +635,4 @@ Run `$prp-issue fix {number}` to execute the plan.
 - **IMPLEMENTABLE**: Another agent can execute without questions
 - **GITHUB_POSTED**: Comment visible on issue (if GH issue)
 - **STORED**: Artifact saved in the PRP store
+- **HANDED OFF**: If the invocation asked for the fix too, `workflows/fix.md` has been READ and is being executed — not improvised from the plan you just wrote

--- a/.claude/skills/prp-issue/SKILL.md
+++ b/.claude/skills/prp-issue/SKILL.md
@@ -30,9 +30,19 @@ Read the first token of `$ARGUMENTS` to choose the workflow. Everything after th
 |-------------|----------|-------------|
 | `investigate` | `workflows/investigate.md` | issue number / URL / free-form description |
 | `fix` | `workflows/fix.md` | issue number / artifact path (`+ optional --base <branch>`) |
+| **both verbs** — `investigate and fix`, `investigate then fix` | `workflows/investigate.md`, **then** `workflows/fix.md` | the issue; the artifact the first phase writes is the second phase's input |
 | _no verb_ (a bare issue number, URL, or description) | `workflows/investigate.md` | the whole argument — investigation is the entry point; you investigate before you fix |
 
-**Action**: strip the leading verb (if present), then follow the matching workflow file end-to-end. Do not blend the two — pick one and execute it fully.
+**Action**: strip the verb(s), then follow each matching workflow file end-to-end, in the order above.
+
+**Read the workflow file for every phase you run — including the second one.** Both phases asked for
+means both files read. Finishing an investigation leaves you holding a plan and feeling ready to
+implement it, and implementing from that feeling is the failure this line exists to stop: `fix.md`
+carries the branch discipline, the validation gate, the PR, the agent review and the archive, and an
+agent that never opened it silently does none of them. It has happened.
+
+**Do not blend them.** Sequential, each run to its end — not interleaved, and not one phase
+improvising the other's steps from memory.
 
 ---
 

--- a/.claude/skills/prp-issue/workflows/investigate.md
+++ b/.claude/skills/prp-issue/workflows/investigate.md
@@ -14,6 +14,9 @@ Investigate the issue/problem and produce a comprehensive implementation plan th
 
 **Golden Rule**: The artifact you produce IS the specification. The implementing agent should be able to work from it without asking questions.
 
+**If the operator asked to investigate *and* fix, this file is only your first half** — see "If the
+invocation also asked for the fix" below before you stop or start editing code.
+
 ---
 
 ## Phase 1: PARSE - Understand Input
@@ -574,6 +577,28 @@ Run `/prp-issue fix {number}` to execute the plan.
 
 ---
 
+## If the invocation also asked for the fix
+
+Investigation ends here **only** when the operator asked to investigate. If they asked for both —
+`investigate and fix`, `investigate this and fix it`, or any phrasing carrying both — you are half
+done, and the next thing you do is:
+
+**Read `workflows/fix.md` and execute it end-to-end, with the artifact you just wrote as its input.**
+
+Read the file. Do not implement from what is in your head right now.
+
+You are holding a fresh, detailed, correct plan, which is exactly what makes this the moment the
+step gets skipped: implementing feels like the obvious next move and the file feels redundant. It
+is not. `fix.md` is seven phases you have not seen — artifact drift check, branch discipline, the
+validation gate, commit and PR, review by the review agents and acting on their findings, and the
+archive. An agent that goes straight to editing performs none of them and produces a plausible diff
+with no PR, no review and no artifact archived. That is a real run, not a hypothetical.
+
+The "Next Step" line above is what you print for the operator when they asked only to investigate.
+It is not permission to stop when they asked for more.
+
+---
+
 ## Handling Edge Cases
 
 ### Issue is already closed
@@ -608,3 +633,4 @@ Run `/prp-issue fix {number}` to execute the plan.
 - **IMPLEMENTABLE**: Another agent can execute without questions
 - **GITHUB_POSTED**: Comment visible on issue (if GH issue)
 - **STORED**: Artifact saved in the PRP store
+- **HANDED OFF**: If the invocation asked for the fix too, `workflows/fix.md` has been READ and is being executed — not improvised from the plan you just wrote

--- a/plugins/prp-core/skills/prp-issue/SKILL.md
+++ b/plugins/prp-core/skills/prp-issue/SKILL.md
@@ -30,9 +30,19 @@ Read the first token of `$ARGUMENTS` to choose the workflow. Everything after th
 |-------------|----------|-------------|
 | `investigate` | `workflows/investigate.md` | issue number / URL / free-form description |
 | `fix` | `workflows/fix.md` | issue number / artifact path (`+ optional --base <branch>`) |
+| **both verbs** — `investigate and fix`, `investigate then fix` | `workflows/investigate.md`, **then** `workflows/fix.md` | the issue; the artifact the first phase writes is the second phase's input |
 | _no verb_ (a bare issue number, URL, or description) | `workflows/investigate.md` | the whole argument — investigation is the entry point; you investigate before you fix |
 
-**Action**: strip the leading verb (if present), then follow the matching workflow file end-to-end. Do not blend the two — pick one and execute it fully.
+**Action**: strip the verb(s), then follow each matching workflow file end-to-end, in the order above.
+
+**Read the workflow file for every phase you run — including the second one.** Both phases asked for
+means both files read. Finishing an investigation leaves you holding a plan and feeling ready to
+implement it, and implementing from that feeling is the failure this line exists to stop: `fix.md`
+carries the branch discipline, the validation gate, the PR, the agent review and the archive, and an
+agent that never opened it silently does none of them. It has happened.
+
+**Do not blend them.** Sequential, each run to its end — not interleaved, and not one phase
+improvising the other's steps from memory.
 
 ---
 

--- a/plugins/prp-core/skills/prp-issue/workflows/investigate.md
+++ b/plugins/prp-core/skills/prp-issue/workflows/investigate.md
@@ -14,6 +14,9 @@ Investigate the issue/problem and produce a comprehensive implementation plan th
 
 **Golden Rule**: The artifact you produce IS the specification. The implementing agent should be able to work from it without asking questions.
 
+**If the operator asked to investigate *and* fix, this file is only your first half** — see "If the
+invocation also asked for the fix" below before you stop or start editing code.
+
 ---
 
 ## Phase 1: PARSE - Understand Input
@@ -574,6 +577,28 @@ Run `/prp-issue fix {number}` to execute the plan.
 
 ---
 
+## If the invocation also asked for the fix
+
+Investigation ends here **only** when the operator asked to investigate. If they asked for both —
+`investigate and fix`, `investigate this and fix it`, or any phrasing carrying both — you are half
+done, and the next thing you do is:
+
+**Read `workflows/fix.md` and execute it end-to-end, with the artifact you just wrote as its input.**
+
+Read the file. Do not implement from what is in your head right now.
+
+You are holding a fresh, detailed, correct plan, which is exactly what makes this the moment the
+step gets skipped: implementing feels like the obvious next move and the file feels redundant. It
+is not. `fix.md` is seven phases you have not seen — artifact drift check, branch discipline, the
+validation gate, commit and PR, review by the review agents and acting on their findings, and the
+archive. An agent that goes straight to editing performs none of them and produces a plausible diff
+with no PR, no review and no artifact archived. That is a real run, not a hypothetical.
+
+The "Next Step" line above is what you print for the operator when they asked only to investigate.
+It is not permission to stop when they asked for more.
+
+---
+
 ## Handling Edge Cases
 
 ### Issue is already closed
@@ -608,3 +633,4 @@ Run `/prp-issue fix {number}` to execute the plan.
 - **IMPLEMENTABLE**: Another agent can execute without questions
 - **GITHUB_POSTED**: Comment visible on issue (if GH issue)
 - **STORED**: Artifact saved in the PRP store
+- **HANDED OFF**: If the invocation asked for the fix too, `workflows/fix.md` has been READ and is being executed — not improvised from the plan you just wrote


### PR DESCRIPTION
From a real run: `prp-issue investigate and fix <n>` investigated, then implemented straight from the
plan it had just written. It **never opened `workflows/fix.md`** — so no branch discipline, no
validation gate, no PR, no agent review, no archive. A plausible diff and none of the workflow.

## The skill told it to do that

Routing reads the **first token**. `investigate and fix` matched `investigate` and nothing else, and
the action line closed with:

> Do not blend the two — pick one and execute it fully.

That rule exists to stop the phases interleaving. Read at the end of an investigation it says: *you
picked investigate, you're done.* The operator had asked for a fix, so the agent did one — from
memory, because nothing pointed it at the file.

Note this is orthogonal to #32. That fixed *what the review phase does*; this is about the review
phase never being reached at all.

## Changes

**`SKILL.md`** — a routing row for both verbs (`investigate and fix`, `investigate then fix`):
investigate.md, *then* fix.md, with the artifact as the second phase's input. "Do not blend" now
means don't interleave and don't improvise — sequential is correct, and each phase reads its own
file.

**`workflows/investigate.md`** — the load-bearing half, because that is the file the agent is
actually holding 100k tokens later. Nobody re-reads `SKILL.md` to find out what happens next. A
closing section says an invocation naming both phases means `fix.md` gets **read** and executed, and
it names why this is exactly where the step gets skipped: you are holding a fresh, correct, detailed
plan, which makes implementing feel like the obvious move and the file feel redundant. It is seven
phases you have not seen. Bookended with a pointer under the Golden Rule and a `HANDED OFF` success
criterion, so it is visible on the way in and on the way out.

The `Next Step: run /prp-issue fix {number}` line is what you **print for the operator** when only an
investigation was asked for. It is now stated that this is not permission to stop when more was
asked.

## Validation

- `python3 scripts/sync_plugin.py --check` — all targets in sync.
- Claude plugin and Codex renders regenerated.

## Still true, and not fixed by merging this

The installed plugin caches (`~/.claude/plugins/cache/prp-marketplace/prp-core/{a643e84,f171068}`)
are pinned to 27 July and still carry the old text. Sessions keep reading the stale skill until the
plugin cache updates.
