### PR TITLE
fix(prp-core): prp-issue full verb + review gate, and isolate orchestrate workstreams by default

### DIFF
--- a/.agents/skills/prp-issue/SKILL.md
+++ b/.agents/skills/prp-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prp-issue
-description: Investigate a GitHub issue and implement the fix - analyze codebase, create a plan, then code, PR, review by the review agents, and act on their findings. Use when the user wants to investigate or triage a GitHub issue or bug report, fix an investigated issue, implement an issue fix, or invokes $prp-issue.
+description: Investigate a GitHub issue and implement the fix - analyze codebase, create a plan, then code, PR, review by the review agents, and act on their findings. Use when the user wants to investigate or triage a GitHub issue or bug report, fix an investigated issue, implement an issue fix, run the full cycle on an issue end to end, or invokes $prp-issue.
 ---
 
 > **Arguments:** `$ARGUMENTS` (and `$1`, `$2`, ...) refer to the arguments given when this skill was invoked. Take them from the user's request; if absent, infer them from the conversation.
@@ -19,7 +19,7 @@ PRP_DIR="${PRP_HOME:-$HOME/.prp}/${_name:-project}-$(printf %s "$_root" | git ha
 mkdir -p "$PRP_DIR"; [ -f "$PRP_DIR/project.json" ] || printf '{"path": "%s", "name": "%s"}\n' "$_root" "${_name:-project}" > "$PRP_DIR/project.json"
 ```
 
-Two-phase issue workflow: **investigate** an issue into an implementation artifact, then **fix** it from that artifact (code, PR, agent review, act on findings).
+Two-phase issue workflow: **investigate** an issue into an implementation artifact, then **fix** it from that artifact (code, PR, agent review, act on findings). `full` runs both in one pass.
 
 ---
 
@@ -31,10 +31,22 @@ Read the first token of `$ARGUMENTS` to choose the workflow. Everything after th
 |-------------|----------|-------------|
 | `investigate` | `workflows/investigate.md` | issue number / URL / free-form description |
 | `fix` | `workflows/fix.md` | issue number / artifact path (`+ optional --base <branch>`) |
-| **both verbs** — `investigate and fix`, `investigate then fix` | `workflows/investigate.md`, **then** `workflows/fix.md` | the issue; the artifact the first phase writes is the second phase's input |
+| `full` — and every equivalent: `all`, `everything`, `end to end`, `investigate and fix`, `investigate then fix`, `fix it too`, `ship it` | `workflows/investigate.md`, **then** `workflows/fix.md` | the issue; the artifact the first phase writes is the second phase's input |
 | _no verb_ (a bare issue number, URL, or description) | `workflows/investigate.md` | the whole argument — investigation is the entry point; you investigate before you fix |
 
 **Action**: strip the verb(s), then follow each matching workflow file end-to-end, in the order above.
+
+### Where a run is allowed to stop
+
+Two routes end early, and they are the only two:
+
+- **`investigate`**, or a bare issue with no verb — ends at the artifact.
+- **`fix`** — starts from the artifact an earlier investigation already wrote.
+
+Every other invocation runs the full cycle: investigate → implement → validate → commit → PR →
+review by the review agents → findings posted → the worthwhile ones fixed → committed and pushed.
+The verb list above is illustrative, not exhaustive; when the wording does not plainly limit you to
+one of the two early-stopping routes, run the full cycle.
 
 **Read the workflow file for every phase you run — including the second one.** Both phases asked for
 means both files read. Finishing an investigation leaves you holding a plan and feeling ready to
@@ -51,4 +63,6 @@ improvising the other's steps from memory.
 
 - `investigate` is read-mostly: it analyzes, writes an artifact under `$PRP_DIR/issues/`, and (for GitHub issues) posts a comment.
 - `fix` is **side-effecting**: it creates a branch, commits, opens a PR, has the review agents review it, and pushes fixes for what they find. Only run it once an investigation artifact exists.
-- Typical flow: `prp-issue investigate <number>` → review the artifact → `prp-issue fix <number>`.
+- `full` is both, back to back, in one run — no stop between the artifact and the branch.
+- Staged flow, to read the plan before any code is written: `prp-issue investigate <number>` → read the artifact → `prp-issue fix <number>`.
+- One-shot flow: `prp-issue full <number>`.

--- a/.agents/skills/prp-issue/workflows/fix.md
+++ b/.agents/skills/prp-issue/workflows/fix.md
@@ -452,26 +452,23 @@ PR_NUMBER=$(gh pr view --json number -q '.number')
 
 ## Phase 8: REVIEW - Review the PR, then act on it
 
-**Do not review your own diff.** You just wrote it, so you are the worst available reader of it —
-you will re-derive the reasoning that produced the bug instead of noticing the bug. Dispatch the
-review, then spend your turn on what it finds.
+The review agents read the diff; you read what they report. Dispatch the review first, then spend
+the rest of this phase acting on its findings.
 
-### 8.1 Run the general review
+### 8.1 Run the review
 
-Invoke the review skill against the PR you just opened:
-
-```
-$prp-review {pr-number} --agents code simplify
-```
+Run the `prp-review` skill with arguments `{pr-number} --agents code simplify`.
 
 That is the whole of this step. It dispatches the reviewers, writes
 `$PRP_DIR/reviews/pr-{pr-number}-review.md`, and posts the summary to the PR.
 
-- **Two agents, named on purpose — not `all`.** `code` and `simplify` are `code-reviewer`
-  and `code-simplifier`. This workflow ships one artifact-sized fix, and the full aspect
-  stack costs more than that fix is worth. Reach for `--agents all` by hand on a PR that earns it.
-- **Do not post your own review comment.** The review skill already posted one, and a second
-  summary written by the author of the code is exactly the self-review this phase exists to avoid.
+- **`code` is mandatory.** It is `code-reviewer`, and it is what makes this phase a review
+  rather than a formality. Keep it in the aspect list on every run.
+- **`simplify` rides along** — `code-simplifier`, cheap on a diff this size. This workflow
+  ships one artifact-sized fix, so the full aspect stack costs more than the fix is worth; reach for
+  `--agents all` by hand on a PR that earns it.
+- **The review comment on the PR is written by the review skill.** Your own comment comes later, in
+  8.3, and it records what you applied and what you declined.
 
 ### 8.2 Act on the findings
 
@@ -522,7 +519,8 @@ fixing at all, say that in one line instead of posting the template.
 
 **PHASE_8_CHECKPOINT:**
 
-- [ ] `prp-review --agents` dispatched against the PR; report written and posted by it
+- [ ] `prp-review --agents` dispatched against the PR with `code` among the aspects; report written and posted by it
+- [ ] `$PRP_DIR/reviews/pr-{pr-number}-review.md` exists on disk
 - [ ] Critical and Important findings fixed, or explicitly rejected with a reason
 - [ ] Suggestions judged individually; over-engineered ones declined
 - [ ] Validation re-run and green after any change; commits pushed
@@ -531,6 +529,21 @@ fixing at all, say that in one line instead of posting the template.
 ---
 
 ## Phase 9: ARCHIVE - Clean Up
+
+### 9.0 Gate: the review left a file
+
+Phase 8 writes a report to a known path. Check for it before archiving anything:
+
+```bash
+ls -1 "$PRP_DIR/reviews/pr-{pr-number}-review.md"
+```
+
+**Exit 0 — the review ran.** Continue to 9.1.
+
+**Non-zero — Phase 8 did not run.** Go back to Phase 8, run it, act on the findings, and return
+here. This is a file check rather than a question you answer from memory, because by this point in
+the run the memory is the unreliable part: the PR is open, the diff is green, and the work reads as
+finished several phases before it is. Archiving is the last step of a reviewed fix.
 
 ### 9.1 Move Artifact to Completed
 
@@ -547,6 +560,7 @@ Do **not** stage, commit, or push the archive; it is stored outside the reposito
 
 **PHASE_9_CHECKPOINT:**
 
+- [ ] Review report confirmed present on disk before archiving
 - [ ] Artifact moved to the PRP store's completed folder
 
 ---
@@ -637,7 +651,7 @@ Do **not** stage, commit, or push the archive; it is stored outside the reposito
 - **PLAN_EXECUTED**: All artifact steps completed
 - **VALIDATION_PASSED**: All checks green
 - **PR_CREATED**: PR exists and linked to issue
-- **REVIEWED_BY_AGENTS**: `prp-review --agents` run against the PR, its report posted
+- **REVIEWED_BY_AGENTS**: `prp-review --agents` run against the PR with `code` among the aspects; `$PRP_DIR/reviews/pr-{pr-number}-review.md` exists and its summary is posted
 - **FINDINGS_ACTIONED**: Every Critical/Important fixed or rejected with a reason; declines stated on the PR
 - **ARTIFACT_ARCHIVED**: Moved to completed folder
 - **AUDIT_TRAIL**: GitHub comment and PRP-store artifact history

--- a/.agents/skills/prp-issue/workflows/investigate.md
+++ b/.agents/skills/prp-issue/workflows/investigate.md
@@ -16,8 +16,8 @@ Investigate the issue/problem and produce a comprehensive implementation plan th
 
 **Golden Rule**: The artifact you produce IS the specification. The implementing agent should be able to work from it without asking questions.
 
-**If the operator asked to investigate *and* fix, this file is only your first half** — see "If the
-invocation also asked for the fix" below before you stop or start editing code.
+**Unless the invocation limited you to investigating, this file is only your first half** — see
+"Where this file ends" below before you stop or start editing code.
 
 ---
 
@@ -579,11 +579,11 @@ Run `$prp-issue fix {number}` to execute the plan.
 
 ---
 
-## If the invocation also asked for the fix
+## Where this file ends
 
-Investigation ends here **only** when the operator asked to investigate. If they asked for both —
-`investigate and fix`, `investigate this and fix it`, or any phrasing carrying both — you are half
-done, and the next thing you do is:
+Investigation ends here **only** when the invocation limited you to it: the verb `investigate`
+alone, or a bare issue with no verb. Under `full` — or any wording asking for more than the
+artifact — you are half done, and the next thing you do is:
 
 **Read `workflows/fix.md` and execute it end-to-end, with the artifact you just wrote as its input.**
 
@@ -598,6 +598,10 @@ with no PR, no review and no artifact archived. That is a real run, not a hypoth
 
 The "Next Step" line above is what you print for the operator when they asked only to investigate.
 It is not permission to stop when they asked for more.
+
+**Decide by re-reading the invocation, not by how finished the artifact feels.** A complete artifact
+is what `full` produces at its halfway mark; completeness here says nothing about whether you are
+done.
 
 ---
 
@@ -635,4 +639,4 @@ It is not permission to stop when they asked for more.
 - **IMPLEMENTABLE**: Another agent can execute without questions
 - **GITHUB_POSTED**: Comment visible on issue (if GH issue)
 - **STORED**: Artifact saved in the PRP store
-- **HANDED OFF**: If the invocation asked for the fix too, `workflows/fix.md` has been READ and is being executed — not improvised from the plan you just wrote
+- **HANDED OFF**: Unless the invocation was investigate-only, `workflows/fix.md` has been READ and is being executed — not improvised from the plan you just wrote

--- a/.agents/skills/prp-orchestrate/references/launching.md
+++ b/.agents/skills/prp-orchestrate/references/launching.md
@@ -6,8 +6,12 @@ Mechanics for running workstreams as native background agents (the default), plu
 
 Spawn via your delegation tool:
 
-- **PR-producing workstream** — one background agent with **worktree isolation** so the agent works in its own checkout and cannot collide with the main checkout or other agents. The agent creates its branch, commits, pushes, and opens the PR itself (that is part of its prompt's definition of done).
-- **Read-only workstream** (review, research, triage) — plain background agents, no isolation needed; launch several in a single message so they run concurrently. Prefer the pack's advisory agents (`code-reviewer`, `codebase-analyst`, …) when one matches.
+**`isolation: "worktree"` is the default.** Spawn every workstream that touches the working tree into its own checkout — it cannot then collide with the operator's checkout or with another agent. The exception is narrow, and you must be able to name it: a workstream that only reads files and writes to the PRP store (`prp-codebase-question`, `prp-debug`, `prp-plan`, `prp-prd`) can be a plain background agent. Launch several of those in a single message so they run concurrently.
+
+- The test is **"does it touch the working tree"**, not "does it open a PR". `prp-review` reads as read-only and is not: it runs `gh pr checkout`, which switches branches in whatever checkout it lands in. Run it in the operator's and you have moved their HEAD out from under them mid-session. It gets a worktree.
+- When in doubt, isolate. A worktree costs a few hundred milliseconds and some disk; a workstream that mutates the shared checkout costs the operator their session.
+- **PR-producing workstream** — one agent, `run_in_background` (the default), worktree-isolated. The agent creates its branch, commits, pushes, and opens the PR itself (that is part of its prompt's definition of done).
+- Prefer the pack's advisory agents (`code-reviewer`, `codebase-analyst`, …) when one matches the workstream.
 - Record the agent ID/name the tool returns — it is the handle for messaging, stopping, and status checks, and goes in the run file's workstream row.
 - Respect the run's `--max-parallel`: completion notifications free slots; launch the next queued workstream then.
 
@@ -51,12 +55,12 @@ The STOP-and-report clause is the escalation path: the orchestrator gates the bl
 
 ## Engines per workstream type
 
-| Workstream | Prompt core |
-|---|---|
-| GitHub issue | `Use the prp-issue skill: first investigate #N, then fix #N.` |
-| Feature, plan exists | `Use the prp-implement skill to execute the plan at <path>, then use the prp-pr skill to open a PR.` |
-| Feature, autonomous | `Use the prp-loop skill for: <feature description>.` (the loop handles plan→implement→pr→review; the orchestrator then only gates the final merge) |
-| Plan only (staged) | `Use the prp-plan skill to create an implementation plan for: <feature>.` — gate the plan, then message the same agent to proceed with prp-implement |
+| Workstream           | Prompt core                                                                                                                                              |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GitHub issue         | `Use the prp-issue skill: first investigate #N, then fix #N.`                                                                                            |
+| Feature, plan exists | `Use the prp-implement skill to execute the plan at <path>, then use the prp-pr skill to open a PR.`                                                     |
+| Feature, autonomous  | `Use the prp-loop skill for: <feature description>.` (the loop handles plan→implement→pr→review; the orchestrator then only gates the final merge)       |
+| Plan only (staged)   | `Use the prp-plan skill to create an implementation plan for: <feature>.` — gate the plan, then message the same agent to proceed with prp-implement |
 
 ## Steering, stopping, status
 
@@ -105,7 +109,9 @@ Differences from the default lane: no live steering (course-correct by restartin
 
 ## Cleanup (Phase 7 only)
 
-Order matters: **worktrees release branches, so worktrees go first.** An agent worktree holds the PR branch checked out — `gh pr merge --delete-branch` fails on the local deletion while it exists, so merge *without* `--delete-branch` and clean up after: remove worktrees, then local branches (`-d`), then remote branches (`git push origin --delete <branch>`). A worktree locked by a live (resumable) agent stays until the session ends — leave it and only delete the remote branch.
+Order matters: **worktrees release branches, so worktrees go first.** An agent worktree holds the PR branch checked out — `gh pr merge --delete-branch` fails on the local deletion while it exists, so merge _without_ `--delete-branch` and clean up after: remove worktrees, then local branches (`-d`), then remote branches (`git push origin --delete <branch>`). A worktree locked by a live (resumable) agent stays until the session ends — leave it and only delete the remote branch.
+
+**`git worktree list` tells you which teardown a worktree needs — read the path, not your memory of the run.** A worktree under `.worktrees/` was created by the prp-worktree skill and needs explicit teardown; anything else is the agent tool's and cleans up after itself. The run file records no isolation column on purpose: the filesystem already answers this, and it keeps answering after a resume or a compaction, when your memory of which lane you launched into is exactly what has gone missing.
 
 Harness-managed worktrees may be auto-removed when unchanged; pushed branches survive regardless. For worktrees created via the prp-worktree skill (fallback lane), tear down with the same skill — its rails encode the safety order (refuses dirty worktrees and unmerged branch deletion):
 

--- a/.claude/skills/prp-issue/SKILL.md
+++ b/.claude/skills/prp-issue/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: prp-issue
-description: Investigate a GitHub issue and implement the fix - analyze codebase, create a plan, then code, PR, review by the review agents, and act on their findings. Use when the user wants to investigate or triage a GitHub issue or bug report, fix an investigated issue, implement an issue fix, or invokes /prp-issue.
-argument-hint: "investigate <issue-number|url|\"description\"> | fix <issue-number|artifact-path> [--base <branch>]"
+description: Investigate a GitHub issue and implement the fix - analyze codebase, create a plan, then code, PR, review by the review agents, and act on their findings. Use when the user wants to investigate or triage a GitHub issue or bug report, fix an investigated issue, implement an issue fix, run the full cycle on an issue end to end, or invokes /prp-issue.
+argument-hint: "investigate <issue-number|url|\"description\"> | fix <issue-number|artifact-path> | full <issue-number|url> [--base <branch>]"
 ---
 
 # PRP Issue
@@ -18,7 +18,7 @@ PRP_DIR="${PRP_HOME:-$HOME/.prp}/${_name:-project}-$(printf %s "$_root" | git ha
 mkdir -p "$PRP_DIR"; [ -f "$PRP_DIR/project.json" ] || printf '{"path": "%s", "name": "%s"}\n' "$_root" "${_name:-project}" > "$PRP_DIR/project.json"
 ```
 
-Two-phase issue workflow: **investigate** an issue into an implementation artifact, then **fix** it from that artifact (code, PR, agent review, act on findings).
+Two-phase issue workflow: **investigate** an issue into an implementation artifact, then **fix** it from that artifact (code, PR, agent review, act on findings). `full` runs both in one pass.
 
 ---
 
@@ -30,10 +30,22 @@ Read the first token of `$ARGUMENTS` to choose the workflow. Everything after th
 |-------------|----------|-------------|
 | `investigate` | `workflows/investigate.md` | issue number / URL / free-form description |
 | `fix` | `workflows/fix.md` | issue number / artifact path (`+ optional --base <branch>`) |
-| **both verbs** — `investigate and fix`, `investigate then fix` | `workflows/investigate.md`, **then** `workflows/fix.md` | the issue; the artifact the first phase writes is the second phase's input |
+| `full` — and every equivalent: `all`, `everything`, `end to end`, `investigate and fix`, `investigate then fix`, `fix it too`, `ship it` | `workflows/investigate.md`, **then** `workflows/fix.md` | the issue; the artifact the first phase writes is the second phase's input |
 | _no verb_ (a bare issue number, URL, or description) | `workflows/investigate.md` | the whole argument — investigation is the entry point; you investigate before you fix |
 
 **Action**: strip the verb(s), then follow each matching workflow file end-to-end, in the order above.
+
+### Where a run is allowed to stop
+
+Two routes end early, and they are the only two:
+
+- **`investigate`**, or a bare issue with no verb — ends at the artifact.
+- **`fix`** — starts from the artifact an earlier investigation already wrote.
+
+Every other invocation runs the full cycle: investigate → implement → validate → commit → PR →
+review by the review agents → findings posted → the worthwhile ones fixed → committed and pushed.
+The verb list above is illustrative, not exhaustive; when the wording does not plainly limit you to
+one of the two early-stopping routes, run the full cycle.
 
 **Read the workflow file for every phase you run — including the second one.** Both phases asked for
 means both files read. Finishing an investigation leaves you holding a plan and feeling ready to
@@ -50,4 +62,6 @@ improvising the other's steps from memory.
 
 - `investigate` is read-mostly: it analyzes, writes an artifact under `$PRP_DIR/issues/`, and (for GitHub issues) posts a comment.
 - `fix` is **side-effecting**: it creates a branch, commits, opens a PR, has the review agents review it, and pushes fixes for what they find. Only run it once an investigation artifact exists.
-- Typical flow: `prp-issue investigate <number>` → review the artifact → `prp-issue fix <number>`.
+- `full` is both, back to back, in one run — no stop between the artifact and the branch.
+- Staged flow, to read the plan before any code is written: `prp-issue investigate <number>` → read the artifact → `prp-issue fix <number>`.
+- One-shot flow: `prp-issue full <number>`.

--- a/.claude/skills/prp-issue/workflows/fix.md
+++ b/.claude/skills/prp-issue/workflows/fix.md
@@ -450,26 +450,23 @@ PR_NUMBER=$(gh pr view --json number -q '.number')
 
 ## Phase 8: REVIEW - Review the PR, then act on it
 
-**Do not review your own diff.** You just wrote it, so you are the worst available reader of it —
-you will re-derive the reasoning that produced the bug instead of noticing the bug. Dispatch the
-review, then spend your turn on what it finds.
+The review agents read the diff; you read what they report. Dispatch the review first, then spend
+the rest of this phase acting on its findings.
 
-### 8.1 Run the general review
+### 8.1 Run the review
 
-Invoke the review skill against the PR you just opened:
-
-```
-/prp-core:prp-review {pr-number} --agents code simplify
-```
+Skill tool, `skill: "prp-core:prp-review"`, `args: "{pr-number} --agents code simplify"`.
 
 That is the whole of this step. It dispatches the reviewers, writes
 `$PRP_DIR/reviews/pr-{pr-number}-review.md`, and posts the summary to the PR.
 
-- **Two agents, named on purpose — not `all`.** `code` and `simplify` are `prp-core:code-reviewer`
-  and `prp-core:code-simplifier`. This workflow ships one artifact-sized fix, and the full aspect
-  stack costs more than that fix is worth. Reach for `--agents all` by hand on a PR that earns it.
-- **Do not post your own review comment.** The review skill already posted one, and a second
-  summary written by the author of the code is exactly the self-review this phase exists to avoid.
+- **`code` is mandatory.** It is `prp-core:code-reviewer`, and it is what makes this phase a review
+  rather than a formality. Keep it in the aspect list on every run.
+- **`simplify` rides along** — `prp-core:code-simplifier`, cheap on a diff this size. This workflow
+  ships one artifact-sized fix, so the full aspect stack costs more than the fix is worth; reach for
+  `--agents all` by hand on a PR that earns it.
+- **The review comment on the PR is written by the review skill.** Your own comment comes later, in
+  8.3, and it records what you applied and what you declined.
 
 ### 8.2 Act on the findings
 
@@ -520,7 +517,8 @@ fixing at all, say that in one line instead of posting the template.
 
 **PHASE_8_CHECKPOINT:**
 
-- [ ] `prp-review --agents` dispatched against the PR; report written and posted by it
+- [ ] `prp-review --agents` dispatched against the PR with `code` among the aspects; report written and posted by it
+- [ ] `$PRP_DIR/reviews/pr-{pr-number}-review.md` exists on disk
 - [ ] Critical and Important findings fixed, or explicitly rejected with a reason
 - [ ] Suggestions judged individually; over-engineered ones declined
 - [ ] Validation re-run and green after any change; commits pushed
@@ -529,6 +527,21 @@ fixing at all, say that in one line instead of posting the template.
 ---
 
 ## Phase 9: ARCHIVE - Clean Up
+
+### 9.0 Gate: the review left a file
+
+Phase 8 writes a report to a known path. Check for it before archiving anything:
+
+```bash
+ls -1 "$PRP_DIR/reviews/pr-{pr-number}-review.md"
+```
+
+**Exit 0 — the review ran.** Continue to 9.1.
+
+**Non-zero — Phase 8 did not run.** Go back to Phase 8, run it, act on the findings, and return
+here. This is a file check rather than a question you answer from memory, because by this point in
+the run the memory is the unreliable part: the PR is open, the diff is green, and the work reads as
+finished several phases before it is. Archiving is the last step of a reviewed fix.
 
 ### 9.1 Move Artifact to Completed
 
@@ -545,6 +558,7 @@ Do **not** stage, commit, or push the archive; it is stored outside the reposito
 
 **PHASE_9_CHECKPOINT:**
 
+- [ ] Review report confirmed present on disk before archiving
 - [ ] Artifact moved to the PRP store's completed folder
 
 ---
@@ -635,7 +649,7 @@ Do **not** stage, commit, or push the archive; it is stored outside the reposito
 - **PLAN_EXECUTED**: All artifact steps completed
 - **VALIDATION_PASSED**: All checks green
 - **PR_CREATED**: PR exists and linked to issue
-- **REVIEWED_BY_AGENTS**: `prp-review --agents` run against the PR, its report posted
+- **REVIEWED_BY_AGENTS**: `prp-review --agents` run against the PR with `code` among the aspects; `$PRP_DIR/reviews/pr-{pr-number}-review.md` exists and its summary is posted
 - **FINDINGS_ACTIONED**: Every Critical/Important fixed or rejected with a reason; declines stated on the PR
 - **ARTIFACT_ARCHIVED**: Moved to completed folder
 - **AUDIT_TRAIL**: GitHub comment and PRP-store artifact history

--- a/.claude/skills/prp-issue/workflows/investigate.md
+++ b/.claude/skills/prp-issue/workflows/investigate.md
@@ -14,8 +14,8 @@ Investigate the issue/problem and produce a comprehensive implementation plan th
 
 **Golden Rule**: The artifact you produce IS the specification. The implementing agent should be able to work from it without asking questions.
 
-**If the operator asked to investigate *and* fix, this file is only your first half** — see "If the
-invocation also asked for the fix" below before you stop or start editing code.
+**Unless the invocation limited you to investigating, this file is only your first half** — see
+"Where this file ends" below before you stop or start editing code.
 
 ---
 
@@ -577,11 +577,11 @@ Run `/prp-issue fix {number}` to execute the plan.
 
 ---
 
-## If the invocation also asked for the fix
+## Where this file ends
 
-Investigation ends here **only** when the operator asked to investigate. If they asked for both —
-`investigate and fix`, `investigate this and fix it`, or any phrasing carrying both — you are half
-done, and the next thing you do is:
+Investigation ends here **only** when the invocation limited you to it: the verb `investigate`
+alone, or a bare issue with no verb. Under `full` — or any wording asking for more than the
+artifact — you are half done, and the next thing you do is:
 
 **Read `workflows/fix.md` and execute it end-to-end, with the artifact you just wrote as its input.**
 
@@ -596,6 +596,10 @@ with no PR, no review and no artifact archived. That is a real run, not a hypoth
 
 The "Next Step" line above is what you print for the operator when they asked only to investigate.
 It is not permission to stop when they asked for more.
+
+**Decide by re-reading the invocation, not by how finished the artifact feels.** A complete artifact
+is what `full` produces at its halfway mark; completeness here says nothing about whether you are
+done.
 
 ---
 
@@ -633,4 +637,4 @@ It is not permission to stop when they asked for more.
 - **IMPLEMENTABLE**: Another agent can execute without questions
 - **GITHUB_POSTED**: Comment visible on issue (if GH issue)
 - **STORED**: Artifact saved in the PRP store
-- **HANDED OFF**: If the invocation asked for the fix too, `workflows/fix.md` has been READ and is being executed — not improvised from the plan you just wrote
+- **HANDED OFF**: Unless the invocation was investigate-only, `workflows/fix.md` has been READ and is being executed — not improvised from the plan you just wrote

--- a/.claude/skills/prp-orchestrate/references/launching.md
+++ b/.claude/skills/prp-orchestrate/references/launching.md
@@ -6,8 +6,12 @@ Mechanics for running workstreams as native background agents (the default), plu
 
 Spawn via the Agent/Task tool:
 
-- **PR-producing workstream** — one agent, `run_in_background` (the default), **`isolation: "worktree"`** so the agent works in its own checkout and cannot collide with the main checkout or other agents. The agent creates its branch, commits, pushes, and opens the PR itself (that is part of its prompt's definition of done).
-- **Read-only workstream** (review, research, triage) — plain background agents, no isolation needed; launch several in a single message so they run concurrently. Prefer the pack's advisory agents (`prp-core:code-reviewer`, `prp-core:codebase-analyst`, …) when one matches.
+**`isolation: "worktree"` is the default.** Spawn every workstream that touches the working tree into its own checkout — it cannot then collide with the operator's checkout or with another agent. The exception is narrow, and you must be able to name it: a workstream that only reads files and writes to the PRP store (`prp-codebase-question`, `prp-debug`, `prp-plan`, `prp-prd`) can be a plain background agent. Launch several of those in a single message so they run concurrently.
+
+- The test is **"does it touch the working tree"**, not "does it open a PR". `prp-review` reads as read-only and is not: it runs `gh pr checkout`, which switches branches in whatever checkout it lands in. Run it in the operator's and you have moved their HEAD out from under them mid-session. It gets a worktree.
+- When in doubt, isolate. A worktree costs a few hundred milliseconds and some disk; a workstream that mutates the shared checkout costs the operator their session.
+- **PR-producing workstream** — one agent, `run_in_background` (the default), worktree-isolated. The agent creates its branch, commits, pushes, and opens the PR itself (that is part of its prompt's definition of done).
+- Prefer the pack's advisory agents (`prp-core:code-reviewer`, `prp-core:codebase-analyst`, …) when one matches the workstream.
 - Record the agent ID/name the tool returns — it is the handle for SendMessage, stop, and status, and goes in the run file's workstream row.
 - Respect the run's `--max-parallel`: completion notifications free slots; launch the next queued workstream then.
 
@@ -51,12 +55,12 @@ The STOP-and-report clause is the escalation path: the orchestrator gates the bl
 
 ## Engines per workstream type
 
-| Workstream | Prompt core |
-|---|---|
-| GitHub issue | `Use the prp-issue skill: first investigate #N, then fix #N.` |
-| Feature, plan exists | `Use the prp-implement skill to execute the plan at <path>, then use the prp-pr skill to open a PR.` |
-| Feature, autonomous | `Use the prp-loop skill for: <feature description>.` (the loop handles plan→implement→pr→review; the orchestrator then only gates the final merge) |
-| Plan only (staged) | `Use the prp-plan skill to create an implementation plan for: <feature>.` — gate the plan, then SendMessage the same agent to proceed with prp-implement |
+| Workstream           | Prompt core                                                                                                                                              |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GitHub issue         | `Use the prp-issue skill: first investigate #N, then fix #N.`                                                                                            |
+| Feature, plan exists | `Use the prp-implement skill to execute the plan at <path>, then use the prp-pr skill to open a PR.`                                                     |
+| Feature, autonomous  | `Use the prp-loop skill for: <feature description>.` (the loop handles plan→implement→pr→review; the orchestrator then only gates the final merge)       |
+| Plan only (staged)   | `Use the prp-plan skill to create an implementation plan for: <feature>.` — gate the plan, then SendMessage the same agent to proceed with prp-implement |
 
 ## Steering, stopping, status
 
@@ -106,7 +110,9 @@ Differences from the default lane: no SendMessage (course-correct by restarting 
 
 ## Cleanup (Phase 7 only)
 
-Order matters: **worktrees release branches, so worktrees go first.** An agent-tool worktree holds the PR branch checked out — `gh pr merge --delete-branch` fails on the local deletion while it exists, so merge *without* `--delete-branch` and clean up after: remove worktrees, then local branches (`-d`), then remote branches (`git push origin --delete <branch>`). A worktree locked by a live (resumable) agent stays until the session ends — leave it and only delete the remote branch.
+Order matters: **worktrees release branches, so worktrees go first.** An agent-tool worktree holds the PR branch checked out — `gh pr merge --delete-branch` fails on the local deletion while it exists, so merge _without_ `--delete-branch` and clean up after: remove worktrees, then local branches (`-d`), then remote branches (`git push origin --delete <branch>`). A worktree locked by a live (resumable) agent stays until the session ends — leave it and only delete the remote branch.
+
+**`git worktree list` tells you which teardown a worktree needs — read the path, not your memory of the run.** A worktree under `.worktrees/` was created by the prp-worktree skill and needs explicit teardown; anything else is the agent tool's and cleans up after itself. The run file records no isolation column on purpose: the filesystem already answers this, and it keeps answering after a resume or a compaction, when your memory of which lane you launched into is exactly what has gone missing.
 
 Agent-tool worktrees are auto-removed when unchanged; pushed branches survive regardless. For worktrees created via the prp-worktree skill (fallback lane), tear down with the same skill — its rails encode the safety order (refuses dirty worktrees and unmerged branch deletion):
 

--- a/plugins/prp-core/skills/prp-issue/SKILL.md
+++ b/plugins/prp-core/skills/prp-issue/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: prp-issue
-description: Investigate a GitHub issue and implement the fix - analyze codebase, create a plan, then code, PR, review by the review agents, and act on their findings. Use when the user wants to investigate or triage a GitHub issue or bug report, fix an investigated issue, implement an issue fix, or invokes /prp-issue.
-argument-hint: "investigate <issue-number|url|\"description\"> | fix <issue-number|artifact-path> [--base <branch>]"
+description: Investigate a GitHub issue and implement the fix - analyze codebase, create a plan, then code, PR, review by the review agents, and act on their findings. Use when the user wants to investigate or triage a GitHub issue or bug report, fix an investigated issue, implement an issue fix, run the full cycle on an issue end to end, or invokes /prp-issue.
+argument-hint: "investigate <issue-number|url|\"description\"> | fix <issue-number|artifact-path> | full <issue-number|url> [--base <branch>]"
 ---
 
 # PRP Issue
@@ -18,7 +18,7 @@ PRP_DIR="${PRP_HOME:-$HOME/.prp}/${_name:-project}-$(printf %s "$_root" | git ha
 mkdir -p "$PRP_DIR"; [ -f "$PRP_DIR/project.json" ] || printf '{"path": "%s", "name": "%s"}\n' "$_root" "${_name:-project}" > "$PRP_DIR/project.json"
 ```
 
-Two-phase issue workflow: **investigate** an issue into an implementation artifact, then **fix** it from that artifact (code, PR, agent review, act on findings).
+Two-phase issue workflow: **investigate** an issue into an implementation artifact, then **fix** it from that artifact (code, PR, agent review, act on findings). `full` runs both in one pass.
 
 ---
 
@@ -30,10 +30,22 @@ Read the first token of `$ARGUMENTS` to choose the workflow. Everything after th
 |-------------|----------|-------------|
 | `investigate` | `workflows/investigate.md` | issue number / URL / free-form description |
 | `fix` | `workflows/fix.md` | issue number / artifact path (`+ optional --base <branch>`) |
-| **both verbs** — `investigate and fix`, `investigate then fix` | `workflows/investigate.md`, **then** `workflows/fix.md` | the issue; the artifact the first phase writes is the second phase's input |
+| `full` — and every equivalent: `all`, `everything`, `end to end`, `investigate and fix`, `investigate then fix`, `fix it too`, `ship it` | `workflows/investigate.md`, **then** `workflows/fix.md` | the issue; the artifact the first phase writes is the second phase's input |
 | _no verb_ (a bare issue number, URL, or description) | `workflows/investigate.md` | the whole argument — investigation is the entry point; you investigate before you fix |
 
 **Action**: strip the verb(s), then follow each matching workflow file end-to-end, in the order above.
+
+### Where a run is allowed to stop
+
+Two routes end early, and they are the only two:
+
+- **`investigate`**, or a bare issue with no verb — ends at the artifact.
+- **`fix`** — starts from the artifact an earlier investigation already wrote.
+
+Every other invocation runs the full cycle: investigate → implement → validate → commit → PR →
+review by the review agents → findings posted → the worthwhile ones fixed → committed and pushed.
+The verb list above is illustrative, not exhaustive; when the wording does not plainly limit you to
+one of the two early-stopping routes, run the full cycle.
 
 **Read the workflow file for every phase you run — including the second one.** Both phases asked for
 means both files read. Finishing an investigation leaves you holding a plan and feeling ready to
@@ -50,4 +62,6 @@ improvising the other's steps from memory.
 
 - `investigate` is read-mostly: it analyzes, writes an artifact under `$PRP_DIR/issues/`, and (for GitHub issues) posts a comment.
 - `fix` is **side-effecting**: it creates a branch, commits, opens a PR, has the review agents review it, and pushes fixes for what they find. Only run it once an investigation artifact exists.
-- Typical flow: `prp-issue investigate <number>` → review the artifact → `prp-issue fix <number>`.
+- `full` is both, back to back, in one run — no stop between the artifact and the branch.
+- Staged flow, to read the plan before any code is written: `prp-issue investigate <number>` → read the artifact → `prp-issue fix <number>`.
+- One-shot flow: `prp-issue full <number>`.

--- a/plugins/prp-core/skills/prp-issue/workflows/fix.md
+++ b/plugins/prp-core/skills/prp-issue/workflows/fix.md
@@ -450,26 +450,23 @@ PR_NUMBER=$(gh pr view --json number -q '.number')
 
 ## Phase 8: REVIEW - Review the PR, then act on it
 
-**Do not review your own diff.** You just wrote it, so you are the worst available reader of it —
-you will re-derive the reasoning that produced the bug instead of noticing the bug. Dispatch the
-review, then spend your turn on what it finds.
+The review agents read the diff; you read what they report. Dispatch the review first, then spend
+the rest of this phase acting on its findings.
 
-### 8.1 Run the general review
+### 8.1 Run the review
 
-Invoke the review skill against the PR you just opened:
-
-```
-/prp-core:prp-review {pr-number} --agents code simplify
-```
+Skill tool, `skill: "prp-core:prp-review"`, `args: "{pr-number} --agents code simplify"`.
 
 That is the whole of this step. It dispatches the reviewers, writes
 `$PRP_DIR/reviews/pr-{pr-number}-review.md`, and posts the summary to the PR.
 
-- **Two agents, named on purpose — not `all`.** `code` and `simplify` are `prp-core:code-reviewer`
-  and `prp-core:code-simplifier`. This workflow ships one artifact-sized fix, and the full aspect
-  stack costs more than that fix is worth. Reach for `--agents all` by hand on a PR that earns it.
-- **Do not post your own review comment.** The review skill already posted one, and a second
-  summary written by the author of the code is exactly the self-review this phase exists to avoid.
+- **`code` is mandatory.** It is `prp-core:code-reviewer`, and it is what makes this phase a review
+  rather than a formality. Keep it in the aspect list on every run.
+- **`simplify` rides along** — `prp-core:code-simplifier`, cheap on a diff this size. This workflow
+  ships one artifact-sized fix, so the full aspect stack costs more than the fix is worth; reach for
+  `--agents all` by hand on a PR that earns it.
+- **The review comment on the PR is written by the review skill.** Your own comment comes later, in
+  8.3, and it records what you applied and what you declined.
 
 ### 8.2 Act on the findings
 
@@ -520,7 +517,8 @@ fixing at all, say that in one line instead of posting the template.
 
 **PHASE_8_CHECKPOINT:**
 
-- [ ] `prp-review --agents` dispatched against the PR; report written and posted by it
+- [ ] `prp-review --agents` dispatched against the PR with `code` among the aspects; report written and posted by it
+- [ ] `$PRP_DIR/reviews/pr-{pr-number}-review.md` exists on disk
 - [ ] Critical and Important findings fixed, or explicitly rejected with a reason
 - [ ] Suggestions judged individually; over-engineered ones declined
 - [ ] Validation re-run and green after any change; commits pushed
@@ -529,6 +527,21 @@ fixing at all, say that in one line instead of posting the template.
 ---
 
 ## Phase 9: ARCHIVE - Clean Up
+
+### 9.0 Gate: the review left a file
+
+Phase 8 writes a report to a known path. Check for it before archiving anything:
+
+```bash
+ls -1 "$PRP_DIR/reviews/pr-{pr-number}-review.md"
+```
+
+**Exit 0 — the review ran.** Continue to 9.1.
+
+**Non-zero — Phase 8 did not run.** Go back to Phase 8, run it, act on the findings, and return
+here. This is a file check rather than a question you answer from memory, because by this point in
+the run the memory is the unreliable part: the PR is open, the diff is green, and the work reads as
+finished several phases before it is. Archiving is the last step of a reviewed fix.
 
 ### 9.1 Move Artifact to Completed
 
@@ -545,6 +558,7 @@ Do **not** stage, commit, or push the archive; it is stored outside the reposito
 
 **PHASE_9_CHECKPOINT:**
 
+- [ ] Review report confirmed present on disk before archiving
 - [ ] Artifact moved to the PRP store's completed folder
 
 ---
@@ -635,7 +649,7 @@ Do **not** stage, commit, or push the archive; it is stored outside the reposito
 - **PLAN_EXECUTED**: All artifact steps completed
 - **VALIDATION_PASSED**: All checks green
 - **PR_CREATED**: PR exists and linked to issue
-- **REVIEWED_BY_AGENTS**: `prp-review --agents` run against the PR, its report posted
+- **REVIEWED_BY_AGENTS**: `prp-review --agents` run against the PR with `code` among the aspects; `$PRP_DIR/reviews/pr-{pr-number}-review.md` exists and its summary is posted
 - **FINDINGS_ACTIONED**: Every Critical/Important fixed or rejected with a reason; declines stated on the PR
 - **ARTIFACT_ARCHIVED**: Moved to completed folder
 - **AUDIT_TRAIL**: GitHub comment and PRP-store artifact history

--- a/plugins/prp-core/skills/prp-issue/workflows/investigate.md
+++ b/plugins/prp-core/skills/prp-issue/workflows/investigate.md
@@ -14,8 +14,8 @@ Investigate the issue/problem and produce a comprehensive implementation plan th
 
 **Golden Rule**: The artifact you produce IS the specification. The implementing agent should be able to work from it without asking questions.
 
-**If the operator asked to investigate *and* fix, this file is only your first half** — see "If the
-invocation also asked for the fix" below before you stop or start editing code.
+**Unless the invocation limited you to investigating, this file is only your first half** — see
+"Where this file ends" below before you stop or start editing code.
 
 ---
 
@@ -577,11 +577,11 @@ Run `/prp-issue fix {number}` to execute the plan.
 
 ---
 
-## If the invocation also asked for the fix
+## Where this file ends
 
-Investigation ends here **only** when the operator asked to investigate. If they asked for both —
-`investigate and fix`, `investigate this and fix it`, or any phrasing carrying both — you are half
-done, and the next thing you do is:
+Investigation ends here **only** when the invocation limited you to it: the verb `investigate`
+alone, or a bare issue with no verb. Under `full` — or any wording asking for more than the
+artifact — you are half done, and the next thing you do is:
 
 **Read `workflows/fix.md` and execute it end-to-end, with the artifact you just wrote as its input.**
 
@@ -596,6 +596,10 @@ with no PR, no review and no artifact archived. That is a real run, not a hypoth
 
 The "Next Step" line above is what you print for the operator when they asked only to investigate.
 It is not permission to stop when they asked for more.
+
+**Decide by re-reading the invocation, not by how finished the artifact feels.** A complete artifact
+is what `full` produces at its halfway mark; completeness here says nothing about whether you are
+done.
 
 ---
 
@@ -633,4 +637,4 @@ It is not permission to stop when they asked for more.
 - **IMPLEMENTABLE**: Another agent can execute without questions
 - **GITHUB_POSTED**: Comment visible on issue (if GH issue)
 - **STORED**: Artifact saved in the PRP store
-- **HANDED OFF**: If the invocation asked for the fix too, `workflows/fix.md` has been READ and is being executed — not improvised from the plan you just wrote
+- **HANDED OFF**: Unless the invocation was investigate-only, `workflows/fix.md` has been READ and is being executed — not improvised from the plan you just wrote

--- a/plugins/prp-core/skills/prp-orchestrate/references/launching.md
+++ b/plugins/prp-core/skills/prp-orchestrate/references/launching.md
@@ -6,8 +6,12 @@ Mechanics for running workstreams as native background agents (the default), plu
 
 Spawn via the Agent/Task tool:
 
-- **PR-producing workstream** — one agent, `run_in_background` (the default), **`isolation: "worktree"`** so the agent works in its own checkout and cannot collide with the main checkout or other agents. The agent creates its branch, commits, pushes, and opens the PR itself (that is part of its prompt's definition of done).
-- **Read-only workstream** (review, research, triage) — plain background agents, no isolation needed; launch several in a single message so they run concurrently. Prefer the pack's advisory agents (`prp-core:code-reviewer`, `prp-core:codebase-analyst`, …) when one matches.
+**`isolation: "worktree"` is the default.** Spawn every workstream that touches the working tree into its own checkout — it cannot then collide with the operator's checkout or with another agent. The exception is narrow, and you must be able to name it: a workstream that only reads files and writes to the PRP store (`prp-codebase-question`, `prp-debug`, `prp-plan`, `prp-prd`) can be a plain background agent. Launch several of those in a single message so they run concurrently.
+
+- The test is **"does it touch the working tree"**, not "does it open a PR". `prp-review` reads as read-only and is not: it runs `gh pr checkout`, which switches branches in whatever checkout it lands in. Run it in the operator's and you have moved their HEAD out from under them mid-session. It gets a worktree.
+- When in doubt, isolate. A worktree costs a few hundred milliseconds and some disk; a workstream that mutates the shared checkout costs the operator their session.
+- **PR-producing workstream** — one agent, `run_in_background` (the default), worktree-isolated. The agent creates its branch, commits, pushes, and opens the PR itself (that is part of its prompt's definition of done).
+- Prefer the pack's advisory agents (`prp-core:code-reviewer`, `prp-core:codebase-analyst`, …) when one matches the workstream.
 - Record the agent ID/name the tool returns — it is the handle for SendMessage, stop, and status, and goes in the run file's workstream row.
 - Respect the run's `--max-parallel`: completion notifications free slots; launch the next queued workstream then.
 
@@ -51,12 +55,12 @@ The STOP-and-report clause is the escalation path: the orchestrator gates the bl
 
 ## Engines per workstream type
 
-| Workstream | Prompt core |
-|---|---|
-| GitHub issue | `Use the prp-issue skill: first investigate #N, then fix #N.` |
-| Feature, plan exists | `Use the prp-implement skill to execute the plan at <path>, then use the prp-pr skill to open a PR.` |
-| Feature, autonomous | `Use the prp-loop skill for: <feature description>.` (the loop handles plan→implement→pr→review; the orchestrator then only gates the final merge) |
-| Plan only (staged) | `Use the prp-plan skill to create an implementation plan for: <feature>.` — gate the plan, then SendMessage the same agent to proceed with prp-implement |
+| Workstream           | Prompt core                                                                                                                                              |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GitHub issue         | `Use the prp-issue skill: first investigate #N, then fix #N.`                                                                                            |
+| Feature, plan exists | `Use the prp-implement skill to execute the plan at <path>, then use the prp-pr skill to open a PR.`                                                     |
+| Feature, autonomous  | `Use the prp-loop skill for: <feature description>.` (the loop handles plan→implement→pr→review; the orchestrator then only gates the final merge)       |
+| Plan only (staged)   | `Use the prp-plan skill to create an implementation plan for: <feature>.` — gate the plan, then SendMessage the same agent to proceed with prp-implement |
 
 ## Steering, stopping, status
 
@@ -106,7 +110,9 @@ Differences from the default lane: no SendMessage (course-correct by restarting 
 
 ## Cleanup (Phase 7 only)
 
-Order matters: **worktrees release branches, so worktrees go first.** An agent-tool worktree holds the PR branch checked out — `gh pr merge --delete-branch` fails on the local deletion while it exists, so merge *without* `--delete-branch` and clean up after: remove worktrees, then local branches (`-d`), then remote branches (`git push origin --delete <branch>`). A worktree locked by a live (resumable) agent stays until the session ends — leave it and only delete the remote branch.
+Order matters: **worktrees release branches, so worktrees go first.** An agent-tool worktree holds the PR branch checked out — `gh pr merge --delete-branch` fails on the local deletion while it exists, so merge _without_ `--delete-branch` and clean up after: remove worktrees, then local branches (`-d`), then remote branches (`git push origin --delete <branch>`). A worktree locked by a live (resumable) agent stays until the session ends — leave it and only delete the remote branch.
+
+**`git worktree list` tells you which teardown a worktree needs — read the path, not your memory of the run.** A worktree under `.worktrees/` was created by the prp-worktree skill and needs explicit teardown; anything else is the agent tool's and cleans up after itself. The run file records no isolation column on purpose: the filesystem already answers this, and it keeps answering after a resume or a compaction, when your memory of which lane you launched into is exactly what has gone missing.
 
 Agent-tool worktrees are auto-removed when unchanged; pushed branches survive regardless. For worktrees created via the prp-worktree skill (fallback lane), tear down with the same skill — its rails encode the safety order (refuses dirty worktrees and unmerged branch deletion):
 

--- a/scripts/sync_plugin.py
+++ b/scripts/sync_plugin.py
@@ -125,6 +125,9 @@ CODEX_REWRITES: list[tuple[re.Pattern, object]] = [
      "as **two parallel subagents spawned in one step**"),
     (re.compile(r"When launching each agent via Task tool:"), "When spawning each subagent:"),
     (re.compile(r"using Task tool subagents"), "using parallel subagents"),
+    # Skill-tool dispatch -> Codex skill invocation (must precede the prp-core: strip)
+    (re.compile(r'Skill tool, `skill: "prp-core:([a-z-]+)"`, `args: "([^"]*)"`\.'),
+     r"Run the `\1` skill with arguments `\2`."),
     # Codex custom-agent names are flat — drop the plugin namespace
     (re.compile(r"prp-core:"), ""),
     # Claude @-mention context include -> Codex AGENTS.md reality
@@ -211,7 +214,7 @@ CODEX_SKILL_REWRITES: dict[str, list[tuple[re.Pattern, str]]] = {
 
 # Nothing Claude-specific may survive in the Codex render.
 CODEX_FORBIDDEN = (
-    "subagent_type", "Task tool", "prp-core:", "argument-hint:",
+    "subagent_type", "Task tool", "Skill tool", "prp-core:", "argument-hint:",
     "@CLAUDE.md", "${CLAUDE_PLUGIN_ROOT}", ".claude/skills/",
     "SendMessage",
 )
@@ -265,6 +268,9 @@ KILD_REWRITES: list[tuple[re.Pattern, object]] = [
      "**inline, one after the other**"),
     (re.compile(r"When launching each agent via Task tool:"), "For each analysis, inline:"),
     (re.compile(r"using Task tool subagents"), "inline"),
+    # Skill-tool dispatch -> named skill (must precede the prp-core: strip)
+    (re.compile(r'Skill tool, `skill: "prp-core:([a-z-]+)"`, `args: "([^"]*)"`\.'),
+     r"Use the `\1` skill with arguments `\2`."),
     # pi/kild agent names are bare
     (re.compile(r"prp-core:"), ""),
     # pi loads AGENTS.md and CLAUDE.md natively as context files


### PR DESCRIPTION
Two independent fixes to the skill pack.

## prp-issue — the `full` verb, and an archive gated on the review

`prp-issue full <n>` was an undefined route. The verb table knew `investigate`, `fix`, the literal compound phrasings, and bare-no-verb; anything else fell through and the agent improvised the second half from memory instead of reading `fix.md`. What a model's prior says "fix an issue" means is branch, edit, test, commit, PR — Phase 8 is a house convention, not a prior, so it was the phase that reliably went missing while the PR still appeared.

- `full` is a first-class verb, and the stop condition is inverted: only investigate-only and fix-on-an-existing-artifact end early, everything else runs the cycle. The old guard keyed on literal phrasings and could not fire on wording it had not been shown.
- Phase 9 opens with a file check on the review report path — the review either left `$PRP_DIR/reviews/pr-<n>-review.md` or it did not run. By that point in a run, memory is the unreliable part, so this is disk, not recall.
- Phase 8.1 names the tool. It was a bare slash string in an unlabeled fence, which reads as documentation of a command rather than an instruction to call one.
- `code` (code-reviewer) is stated mandatory; `simplify` rides along.
- `sync_plugin.py` renders Skill-tool dispatch into skill invocation for Codex and kild, and the phrase joins the forbidden list. The Codex render had been turning the dispatch into a `$prp-review` mention, leaving that surface with no executable instruction in Phase 8 at all.

## prp-orchestrate — isolate by default, and test for the working tree

The launch rule split workstreams into "PR-producing" (worktree) and "read-only" (plain background agent), which invited classifying by output rather than by what the agent does. `prp-review` lands on the wrong side of that line: it looks read-only, but it runs `gh pr checkout`, so an unisolated review switches branches in the operator's checkout and moves their HEAD mid-session.

- `isolation: "worktree"` is now the default, and the exception is narrow enough to enumerate — skills that only read files and write to the PRP store (`prp-codebase-question`, `prp-debug`, `prp-plan`, `prp-prd`).
- The test is "does it touch the working tree", stated explicitly, with `prp-review` as the worked example of why "does it open a PR" fails.
- Cleanup reads teardown off `git worktree list`: a path under `.worktrees/` is the prp-worktree skill's and needs explicit teardown, anything else is the agent tool's. The run file carries no isolation column on purpose — the filesystem still answers after a compaction, when recall of which lane you launched into is what has gone missing.

Plugin and Codex renders regenerated; `python3 scripts/sync_plugin.py --check` passes.