### PR TITLE
feat(prp-core): add prp-spike — prove or disprove an idea before committing to it

### DIFF
--- a/.agents/skills/prp-spike/SKILL.md
+++ b/.agents/skills/prp-spike/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: prp-spike
+description: Prove or disprove an idea by building the smallest throwaway artifact that could falsify it, in an isolated worktree, ending in a PROVEN / DISPROVEN / CONDITIONAL verdict backed by evidence - never a PR. Use when the user wants to "spike this", "build a proof of concept", "POC this", "prototype it to find out", asks "is this possible", "is this feasible", "does this fit our stack", or "would it be worth changing X to allow Y" and wants it settled by building rather than by analysis, wants to compare approaches on evidence before picking one, or invokes $prp-spike.
+---
+
+> **Arguments:** `$ARGUMENTS` (and `$1`, `$2`, ...) refer to the arguments given when this skill was invoked. Take them from the user's request; if absent, infer them from the conversation.
+
+# PRP Spike — Prove or Disprove
+
+Settle an open question by building the smallest thing that could prove it **wrong**. The deliverable is a verdict backed by evidence, not shippable code.
+
+**Input**: $ARGUMENTS (if absent, take the question from the conversation).
+
+## When to use
+
+- **Feasibility** — can this be built at all, here, with what we have?
+- **Fit** — does this sit naturally in our stack, or fight it the whole way?
+- **Cost of admission** — what would have to change (a primitive, an abstraction, a product constraint) to make it possible, and is that trade worth it?
+- **Choice** — which of several approaches survives contact with the real constraints?
+
+Not for work whose feasibility is already settled — that is `prp-plan` then `prp-implement`. Not for something already broken — that is `prp-debug`.
+
+## The contract
+
+1. A spike answers **one falsifiable question**. No falsifiable question, no spike.
+2. Kill criteria are written **before** the build. Deciding what counts as failure after seeing results turns a spike into a rationalization.
+3. **DISPROVEN is a success.** It bought a decision with evidence and closed a path that would otherwise have cost weeks.
+4. Spike code is throwaway by construction and **never opens a PR**.
+
+## Phase 1 — Frame
+
+Convert the request into a claim that can fail, and fix the kill criteria before touching code.
+
+Produce four things:
+
+- **Hypothesis** — one sentence, falsifiable, specific enough that two people would agree on whether it held.
+- **Slug** — 2–4 lowercase hyphenated words from the hypothesis. It names the branch, the worktree, and the report file; derive it once here and reuse it everywhere.
+- **Kill criteria** — the specific observations that would end this as DISPROVEN, fixed now rather than after results exist.
+- **Boundaries between verdicts** — what separates PROVEN from CONDITIONAL, and CONDITIONAL from DISPROVEN. The kill criteria say what failure looks like; this says which *kind* of failure it is. Deciding that boundary after seeing results is how CONDITIONAL gets rounded to whichever verdict is more convenient.
+
+If the idea carries several independent risks, split it and spike the **riskiest first** — a cheap disproof there saves the rest. One spike run answers one question: take the riskiest here, and list the rest in the report's Recommendation as follow-up spikes. For the framing craft (vague-to-falsifiable rewrites, constraint questions, splitting, sizing), read `references/framing.md`.
+
+If the spike compares approaches, read `references/evidence.md` → **Fair comparison now**. The winning metric must be fixed and recorded here, before either variant exists — a metric chosen afterwards will be the one the favourite happens to win.
+
+State the frame back to the user. When running interactively, confirm an ambiguous hypothesis before building — a spike that answers the wrong question is total waste, and framing is the cheapest thing to correct. When running unattended, record the interpretation chosen and the alternatives rejected, and proceed.
+
+### Record the frame before building
+
+Pre-commitment only counts if it outlives the conversation. Write the frame to disk now — a transcript does not survive compaction, and an agent that has seen its results can reconstruct criteria that flatter them.
+
+```bash
+# --- PRP store resolver (canonical; keep byte-identical across skills) ---
+_gd="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"
+case "$_gd" in */.git) _root="${_gd%/.git}" ;; "") _root="$PWD" ;; *) _root="$_gd" ;; esac
+_root="$(cd "$_root" && pwd -P)"
+_name="$(basename "$_root" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | sed 's/^-*//;s/-*$//')"
+PRP_DIR="${PRP_HOME:-$HOME/.prp}/${_name:-project}-$(printf %s "$_root" | git hash-object --stdin | cut -c1-8)"
+mkdir -p "$PRP_DIR"; [ -f "$PRP_DIR/project.json" ] || printf '{"path": "%s", "name": "%s"}\n' "$_root" "${_name:-project}" > "$PRP_DIR/project.json"
+mkdir -p "$PRP_DIR/spikes"
+```
+
+The resolver keys off the main repo, so the file lands in the shared store and stays readable from the main checkout while the spike branch is untouched.
+
+Read `templates/spike-report.md` now (mandatory) and create `$PRP_DIR/spikes/spike-<slug>.md` with its header, `## The question` section, and `**Verdict**: (pending)`. Phase 6 fills in the rest; the hypothesis, kill criteria, and verdict boundaries recorded here are **never edited after this point**. The pending marker keeps an abandoned spike visibly unfinished instead of reading as a report with a missing verdict.
+
+**GATE**: the file exists and contains the hypothesis, kill criteria, and verdict boundaries. Do not build without it.
+
+## Phase 2 — Isolate
+
+Spike code is disposable and often invasive. Keep it away from the working checkout.
+
+Use the prp-worktree skill to create a worktree named `spike/<slug>`, and work there. The branch is the spike's home; it is never merged.
+
+`--here` skips the worktree — use it only when a fresh checkout cannot run the project (gitignored build prerequisites, an expensive bootstrap, a running local stack). It changes how the spike is captured and torn down; see Phase 7. Record in the report that it was used and why.
+
+## Phase 3 — Research
+
+Read only enough to choose a **credible** approach — one a competent engineer would defend. A spike that fails because of a naive approach has proven nothing about the idea.
+
+- Prefer primary sources: official docs, the dependency's actual source, specs, the codebase itself.
+- Use `web-researcher` for anything outside the training cutoff, and `codebase-analyst` to learn how the relevant subsystem really works before assuming what it allows.
+- Stop when the approach is defensible. Research is not the deliverable here; the build is.
+
+## Phase 4 — Build the falsifier
+
+Build the **smallest artifact that could prove the hypothesis wrong**, then stop.
+
+The shape follows the question, not a catalogue — an interactive demo, a comparison of N implementations against a stated metric, a probe against a real API, a load harness, a type-level sketch, a patched dependency proving a primitive change works. Ask: *what would I have to see to stop believing this?* Build that.
+
+Hold to:
+
+- **Aim at the risk.** Build the part that might fail. Scaffolding, auth, styling, and persistence are not the question — stub them.
+- **No production habits.** No tests, no error handling beyond what keeps it running, no abstractions. Every hour spent making spike code good is an hour not spent learning.
+- **Real inputs.** Real data shapes, real API, real volumes. A spike on synthetic happy-path data proves nothing about production.
+- **Surface the state.** Print or render what the artifact is doing, so the evidence is observable rather than asserted.
+- **Track what got faked.** Every stub is a hole in the proof; the report has to name them.
+
+## Phase 5 — Stress
+
+A spike that only ran the happy path has not been tested — it has been demoed. Attack the claim where it is weakest.
+
+Work the kill criteria from Phase 1 deliberately: push the volume, break the assumption the approach rests on, feed the edge case, pull the dependency. Most spikes earn their keep here.
+
+For evidence standards — what counts as proof, how to make a comparison fair, and the traps that make spikes lie — read `references/evidence.md`.
+
+## Phase 6 — Verdict
+
+**Re-read the kill criteria and verdict boundaries recorded in Phase 1 before choosing — not after.** They were written by someone who had not yet seen these results. That is the only reason they are worth anything.
+
+Reach one verdict:
+
+| Verdict | Meaning |
+|---|---|
+| **PROVEN** | Holds within current constraints. Evidence attached. |
+| **DISPROVEN** | Does not hold. Name the wall it hit and why it is not the approach's fault. |
+| **CONDITIONAL** | Holds only if a named constraint changes. Name the constraint, the cost of changing it, and what else that change would unlock. |
+
+**CONDITIONAL is the verdict most spikes should reach and most reports dodge.** "Impossible" is usually shorthand for "impossible without changing something we were treating as fixed" — a primitive, a schema, a dependency, a product rule. Surfacing that trade is the point: it converts a dead end into a priced decision. Never collapse it into DISPROVEN. Never let it drift into PROVEN by quietly assuming the change is free.
+
+Complete `$PRP_DIR/spikes/spike-<slug>.md` — read `templates/spike-report.md` again (mandatory) and fill every remaining section, replacing `(pending)` with the verdict. Keep every heading; drop only the CONDITIONAL section when the verdict is not CONDITIONAL.
+
+## Phase 7 — Dispose
+
+Commit the spike to its branch, and push it if the repo has a remote. The branch **is** the artifact — the evidence behind the verdict, re-runnable by whoever doubts the result.
+
+- **Never open a PR.** Every other terminal skill in this pack ends in one; this one ends in a verdict.
+- Do not fold spike code into production. A validated approach gets **rewritten** under normal standards, by `prp-plan` and `prp-implement`.
+- Leave the worktree in place if the user may want to poke at it; otherwise tear it down with the prp-worktree skill. The branch survives either way.
+- **Under `--here` there is no spike branch.** Never commit to the branch that was already checked out. Capture the work as a patch — `git diff > "$PRP_DIR/spikes/spike-<slug>.patch"` (add `git diff --cached` and untracked files if either exists) — then restore the checkout to the state it was found in, and record the patch path where the report asks for a branch.
+
+Report to the user: the hypothesis, the verdict, the two or three pieces of evidence that decided it, the branch or patch path, and the report path. Lead with the verdict.
+
+## Gotchas
+
+- **The build phase eats spikes.** Producing something impressive rather than something decisive is the default failure. Return to the hypothesis whenever the next step is unclear.
+- **A working artifact is not a PROVEN hypothesis.** It proves only what it exercised.
+- **Spike effort does not estimate real effort.** Something built in an hour without tests, error handling, or edge cases is not an hour of work. Say this wherever the report could be read as a plan.
+- **Do not let a spike become the implementation.** When the verdict is PROVEN and the code looks decent, the pull to keep going is strong. Stop and hand off.
+
+## Resources
+
+- `references/framing.md` — turning a vague idea into a falsifiable hypothesis with kill criteria; constraint and comparison questions; splitting and sizing
+- `references/evidence.md` — evidence standards, fair comparisons, proving a negative, the traps that make spikes lie (mandatory read in Phase 1 for a comparison spike, before either variant is built; otherwise read in Phase 5)
+- `templates/spike-report.md` — the report to fill (mandatory read in Phase 1 to record the frame, and again in Phase 6 to complete it)

--- a/.agents/skills/prp-spike/references/evidence.md
+++ b/.agents/skills/prp-spike/references/evidence.md
@@ -1,0 +1,67 @@
+# Evidence
+
+A spike's authority comes entirely from its evidence. A confident verdict with weak evidence is worse than no spike — it gets believed.
+
+## Standards
+
+| Counts as evidence | Does not |
+|---|---|
+| Command output actually run, pasted | "This should work" |
+| A measurement, with the conditions it was taken under | A number with no method |
+| An error message hit, with what triggered it | "It would probably fail on..." |
+| Observed behavior of the artifact | Behavior of the artifact as designed |
+| A `file:line` in a real dependency's source | Recollection of how a library behaves |
+| A documented guarantee, cited | An assumed guarantee |
+
+Every claim in the report traces to something observed. Where reasoning fills a gap, mark it as reasoning — the reader needs to know which parts would survive scrutiny.
+
+## "It ran" is not "it works"
+
+A running artifact proves the hypothesis held **under the conditions tried**. The distance between those conditions and production is the real finding, and naming it is the report's honesty test.
+
+Before claiming PROVEN, state plainly:
+
+- **What was stubbed** — every fake is a hole. A spike that mocked the thing it was supposed to test has proven nothing; a spike that mocked the login screen is fine. Know which one this is.
+- **Scale tried vs scale expected** — ten records is not a million. If the volume was not realistic, the volume question is untested, not passed.
+- **Conditions not exercised** — concurrency, failure of a dependency, cold start, hostile input, slow network.
+- **Duration** — anything about leaks, drift, or accumulation is untested by a run that lasted seconds.
+
+## Fair comparison
+
+When the spike compares approaches, the comparison is the experiment and it is easy to rig without meaning to.
+
+- **Fix the metric first.** Before building, name what wins: latency at a percentile, lines of code touched to add a feature, number of concepts a new developer must learn. A metric chosen afterwards will be the one the favourite happens to win.
+- **Vary one thing.** Same data, same hardware, same conditions. An approach also written second, by a more informed author, is not being compared fairly.
+- **Give each approach its best shot.** The failure mode is building the favourite properly and the alternative naively. If one approach is unfamiliar, research it to the same standard before building — a straw man proves nothing.
+- **Repeat measurements.** One run is noise. Discard warmup, run enough times to see the spread, and report the spread rather than the best number.
+- **Report the losers' strengths.** The useful outcome is often "A overall, but B's handling of X is worth stealing." A comparison that only ranks throws away most of what it learned.
+
+Where the metric is taste rather than measurement — how an interaction feels, how an API reads — the artifact's job is to let a human judge, not to decide. Put the variants side by side, make switching trivial, and hand it over. Record whose judgement was applied and on what.
+
+## Proving a negative
+
+DISPROVEN carries a higher burden than PROVEN, because "I could not make it work" and "it cannot work" look identical from the inside.
+
+Before reporting DISPROVEN, establish:
+
+- **The approach was credible** — the way a competent engineer would do it, not the first thing tried.
+- **The obvious alternatives were considered** — and why they fail too, or why they were not tried.
+- **The wall is structural** — a property of the technology, the architecture, or the constraint. If the wall is "this was harder than expected", the finding is a cost estimate, not a disproof.
+- **The failure is reproducible** — the exact command or condition, so the next person can check rather than trust.
+
+Most honest disproofs are actually CONDITIONAL: it cannot work *given something being held fixed*. Name that thing. It is more useful than the disproof.
+
+## Traps
+
+- **Measuring the wrong layer.** A benchmark dominated by JSON serialization says nothing about the database being evaluated. Confirm the measurement is sensitive to the thing under test — change that thing and check the number moves.
+- **Caching.** A second run hitting a warm cache, a memoized result, or a CDN measures the cache. Especially deceptive across variants when one is warmed by the other.
+- **The stub that hid the hard part.** Mocks migrate toward whatever was difficult. Re-read every stub against the hypothesis before concluding.
+- **Synthetic data.** Uniform, clean, small generated data hides exactly the distribution problems, encoding edge cases, and skew that break the real thing.
+- **Confirmation drift.** After investment in an approach, ambiguous results read as success. The pre-committed kill criteria exist for this moment — re-read them before deciding, not after.
+- **The artifact becoming the point.** Time spent polishing something that will be thrown away is time not spent on evidence. Build ugly, learn fast.
+
+## What is still unknown
+
+Every spike ends with an explicit list of what it did not settle. This is not a disclaimer — it bounds the spike's authority and prevents a narrow result being read as a general one.
+
+Include the conditions never exercised, the parts stubbed, the scale untested, and any question the spike raised without answering. A spike that surfaces a better question than it started with has done well; that only lands if the question is written down.

--- a/.agents/skills/prp-spike/references/framing.md
+++ b/.agents/skills/prp-spike/references/framing.md
@@ -1,0 +1,80 @@
+# Framing the Spike
+
+The framing decides whether the spike is worth running. Everything downstream is cheap to redo; this is not.
+
+## The falsifiability test
+
+A hypothesis qualifies when a specific observation would make it false, and that observation is plausible enough to be worth looking for.
+
+Apply two checks:
+
+1. **Name the disproof.** "What would I have to see to stop believing this?" No answer means it is a topic, not a hypothesis.
+2. **Check both outcomes change something.** If PROVEN and DISPROVEN lead to the same next action, the question is not load-bearing. Do not spend a spike on it.
+
+## Vague to falsifiable
+
+| Vague request | Falsifiable hypothesis |
+|---|---|
+| "Can we use X?" | "X can do <specific job> against <our real constraint> without <the thing we fear>." |
+| "Is this fast enough?" | "<Operation> completes within <budget> at <realistic volume> on <representative hardware>." |
+| "Would this feel better?" | "Users can complete <task> in this interaction model without hitting <the confusion we predict>." |
+| "Should we adopt Y?" | "Y handles <the two cases our current thing handles badly> without losing <the case it handles well>." |
+| "Can our schema support Z?" | "Z is representable in the current schema without a migration and without a denormalized write path." |
+
+The pattern: replace the adjective with a threshold, and name the failure being feared. "Fast enough", "clean", "better", "scalable" are all placeholders for a number or a named condition that has not been decided yet. Deciding it is part of the framing, not the build.
+
+## Kill criteria
+
+Write, before building, the observations that would end the spike as DISPROVEN. Good kill criteria are:
+
+- **Observable** — a measurement, an error, a behavior seen, not a feeling.
+- **Pre-committed** — fixed before results exist. A threshold chosen after seeing the number is not a threshold.
+- **Plausible** — at least one must be a real possibility. If every kill criterion is far-fetched, the hypothesis is trivially true and the spike is theatre.
+
+Where a threshold is genuinely unknown, say so explicitly and record the number the spike produces as a **finding** rather than a pass/fail. A spike that establishes the baseline is legitimate; one that invents a threshold to clear afterwards is not.
+
+## Question archetypes
+
+The question type shapes what evidence will be needed. It does not dictate what to build — that follows from what would falsify the claim.
+
+**Feasibility** — can this be done here at all? Evidence is a working (ugly) path through the hardest part. Aim the build at the step most likely to be impossible, not the first step.
+
+**Fit** — does this belong in our stack? Feasibility is usually not in doubt; the question is what it costs in friction. Evidence is the integration seam actually built: where it fights the existing abstractions, what it forces elsewhere, what it would make harder forever.
+
+**Constraint / primitive** — see below.
+
+**Comparison** — which approach wins? The metric that decides it is fixed and recorded during framing, before any variant exists; a metric chosen afterwards will be the one the favourite happens to win. The build then has to give every approach its best shot, or it proves nothing.
+
+## Constraint questions
+
+"Is it worth changing X to allow Y" is a different question from "is Y possible", and it is the one most often mis-framed as the other. Treat the constraint as the variable.
+
+Frame it as: **"Y is impossible under <constraint C>, and possible under <specific relaxation of C>."** Then the spike has two jobs — demonstrate the wall, and demonstrate that moving it actually helps. Skipping the first produces a proposal to change a primitive with no evidence the primitive was the obstacle.
+
+The report has to price the change, not just prove it works:
+
+- **What exactly changes** — the primitive, schema, dependency, or product rule, stated precisely enough to estimate.
+- **Blast radius** — what else depends on the current behavior, and what breaks or needs migrating.
+- **What else it unlocks** — a constraint blocking one feature usually blocks others. This is often what tips the decision, and a spike scoped to one feature is the thing most likely to miss it.
+- **The reversible option** — whether the same result can be had behind a flag, an adapter, or a narrower change. Usually worth one attempt before recommending surgery on a primitive.
+
+A constraint spike that reports "we should change C" without blast radius has done half the work. The decision is a trade, so the evidence must cover both sides.
+
+## Splitting
+
+When an idea carries several independent risks, one spike answering all of them is slow and hard to read. Split into 2–5 questions, each independently falsifiable, and **run the riskiest first** — disproving it makes the rest unnecessary.
+
+Order by *probability of failure*, not by build order or by which is easiest. The cheapest spike is the one never run because an earlier one closed the path.
+
+Signals that a spike is really several:
+- The hypothesis needs "and" between two technical claims.
+- Different parts would be disproven by unrelated evidence.
+- One part is nearly certain and another is a coin flip — the certain part is padding.
+
+## Sizing
+
+The spike ends when the question is answered — not at a time box, and not when the artifact feels finished.
+
+- **Answered early is done.** If the first thing built disproves the hypothesis in twenty minutes, that is the ideal outcome. Do not keep building to justify the exercise.
+- **No end in sight means re-frame.** A spike that keeps growing is usually answering an unfalsifiable question, or several at once. Return here and split.
+- **Blocked on access, not knowledge, is not a spike.** Missing credentials, a licence, or a decision only a human can make is a blocker to report, not a thing to work around with a mock — a mock of the unknown part proves nothing about it.

--- a/.agents/skills/prp-spike/templates/spike-report.md
+++ b/.agents/skills/prp-spike/templates/spike-report.md
@@ -1,0 +1,80 @@
+# Spike Report Template
+
+Written in two passes. In **Phase 1**, create the file with the header (verdict `(pending)`) and `## The question` filled in — that section is the pre-commitment and is never edited afterwards. In **Phase 6**, replace `(pending)` with the verdict and fill everything else.
+
+Lead with the verdict — the reader wants the decision first and the working second.
+
+Drop the CONDITIONAL section when the verdict is not CONDITIONAL. Keep every other section: the ones that bound the result are the ones a reader most needs and an author most wants to skip.
+
+---
+
+```markdown
+# Spike: {question in a few words}
+
+**Verdict**: {(pending) until Phase 6 — then PROVEN | DISPROVEN | CONDITIONAL}
+**Hypothesis**: {the falsifiable claim, as committed before the build}
+**Date**: {YYYY-MM-DD}
+**Evidence**: `{spike/<slug>}` {or, under --here: `spikes/spike-<slug>.patch` — no branch}
+
+## Verdict
+
+{2–4 sentences. What was established, and the single piece of evidence that decided it. If CONDITIONAL, name the constraint here — do not make the reader hunt for it.}
+
+## The question
+
+{Why this was worth a spike: the decision waiting on it, and what each outcome would change.}
+
+**Kill criteria** (committed before building):
+- {observation that would have disproven it}
+- {…}
+
+**Verdict boundaries** (committed before building):
+- PROVEN if {…} · CONDITIONAL if {…} · DISPROVEN if {…}
+
+{In Phase 6: which kill criteria fired, or that none did.}
+
+## What was built
+
+{The artifact, in a few lines: what it does, aimed at which risk. Where it lives on the branch, and the command to run it.}
+
+**Approach**: {the approach taken and why it is a credible one — what a competent engineer would do here.}
+
+## Evidence
+
+{Observed results only. Commands run with their output, measurements with the conditions they were taken under, errors hit with what triggered them. Where reasoning fills a gap, mark it as reasoning.}
+
+{For a comparison: the metric fixed before building, the conditions held equal, results including spread, and what the losing approaches did better.}
+
+## The constraint
+
+**What must change**: {the primitive, schema, dependency, or product rule — precisely enough to estimate}
+
+**Evidence it is the obstacle**: {the wall demonstrated, and that moving it helps}
+
+**Blast radius**: {what depends on current behavior; what breaks or needs migrating}
+
+**Also unlocks**: {other things this constraint currently blocks — often what tips the decision}
+
+**Cheaper option tried**: {flag, adapter, or narrower change — and why it does or does not suffice}
+
+## Limits of this result
+
+- **Stubbed**: {every fake, and whether any of them covered part of the question}
+- **Scale tried**: {vs the scale expected in production}
+- **Not exercised**: {concurrency, dependency failure, cold start, hostile input, duration}
+
+## Still unknown
+
+- {question this spike did not settle}
+- {question this spike raised}
+
+## Recommendation
+
+{What to do next, and what NOT to do. If PROVEN: the plan-and-implement path, and the parts of the real build this spike did not touch. If DISPROVEN: the path now closed, and what to try instead. If CONDITIONAL: the trade, stated as a decision someone can make.}
+
+**Effort**: this spike took {duration} without tests, error handling, or edge cases. That is not an estimate for the real build. {What the real one additionally needs.}
+
+## Reproducing
+
+{Branch — or patch path and the commit it applies to, under --here. How to run it, what to look at. This is the evidence: anyone doubting the verdict should be able to check it rather than trust it.}
+```

--- a/.claude/skills/prp-spike/SKILL.md
+++ b/.claude/skills/prp-spike/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: prp-spike
+description: Prove or disprove an idea by building the smallest throwaway artifact that could falsify it, in an isolated worktree, ending in a PROVEN / DISPROVEN / CONDITIONAL verdict backed by evidence - never a PR. Use when the user wants to "spike this", "build a proof of concept", "POC this", "prototype it to find out", asks "is this possible", "is this feasible", "does this fit our stack", or "would it be worth changing X to allow Y" and wants it settled by building rather than by analysis, wants to compare approaches on evidence before picking one, or invokes /prp-spike.
+argument-hint: "<idea or question> [--here]"
+---
+
+# PRP Spike — Prove or Disprove
+
+Settle an open question by building the smallest thing that could prove it **wrong**. The deliverable is a verdict backed by evidence, not shippable code.
+
+**Input**: $ARGUMENTS (if absent, take the question from the conversation).
+
+## When to use
+
+- **Feasibility** — can this be built at all, here, with what we have?
+- **Fit** — does this sit naturally in our stack, or fight it the whole way?
+- **Cost of admission** — what would have to change (a primitive, an abstraction, a product constraint) to make it possible, and is that trade worth it?
+- **Choice** — which of several approaches survives contact with the real constraints?
+
+Not for work whose feasibility is already settled — that is `prp-plan` then `prp-implement`. Not for something already broken — that is `prp-debug`.
+
+## The contract
+
+1. A spike answers **one falsifiable question**. No falsifiable question, no spike.
+2. Kill criteria are written **before** the build. Deciding what counts as failure after seeing results turns a spike into a rationalization.
+3. **DISPROVEN is a success.** It bought a decision with evidence and closed a path that would otherwise have cost weeks.
+4. Spike code is throwaway by construction and **never opens a PR**.
+
+## Phase 1 — Frame
+
+Convert the request into a claim that can fail, and fix the kill criteria before touching code.
+
+Produce four things:
+
+- **Hypothesis** — one sentence, falsifiable, specific enough that two people would agree on whether it held.
+- **Slug** — 2–4 lowercase hyphenated words from the hypothesis. It names the branch, the worktree, and the report file; derive it once here and reuse it everywhere.
+- **Kill criteria** — the specific observations that would end this as DISPROVEN, fixed now rather than after results exist.
+- **Boundaries between verdicts** — what separates PROVEN from CONDITIONAL, and CONDITIONAL from DISPROVEN. The kill criteria say what failure looks like; this says which *kind* of failure it is. Deciding that boundary after seeing results is how CONDITIONAL gets rounded to whichever verdict is more convenient.
+
+If the idea carries several independent risks, split it and spike the **riskiest first** — a cheap disproof there saves the rest. One spike run answers one question: take the riskiest here, and list the rest in the report's Recommendation as follow-up spikes. For the framing craft (vague-to-falsifiable rewrites, constraint questions, splitting, sizing), read `references/framing.md`.
+
+If the spike compares approaches, read `references/evidence.md` → **Fair comparison now**. The winning metric must be fixed and recorded here, before either variant exists — a metric chosen afterwards will be the one the favourite happens to win.
+
+State the frame back to the user. When running interactively, confirm an ambiguous hypothesis before building — a spike that answers the wrong question is total waste, and framing is the cheapest thing to correct. When running unattended, record the interpretation chosen and the alternatives rejected, and proceed.
+
+### Record the frame before building
+
+Pre-commitment only counts if it outlives the conversation. Write the frame to disk now — a transcript does not survive compaction, and an agent that has seen its results can reconstruct criteria that flatter them.
+
+```bash
+# --- PRP store resolver (canonical; keep byte-identical across skills) ---
+_gd="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"
+case "$_gd" in */.git) _root="${_gd%/.git}" ;; "") _root="$PWD" ;; *) _root="$_gd" ;; esac
+_root="$(cd "$_root" && pwd -P)"
+_name="$(basename "$_root" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | sed 's/^-*//;s/-*$//')"
+PRP_DIR="${PRP_HOME:-$HOME/.prp}/${_name:-project}-$(printf %s "$_root" | git hash-object --stdin | cut -c1-8)"
+mkdir -p "$PRP_DIR"; [ -f "$PRP_DIR/project.json" ] || printf '{"path": "%s", "name": "%s"}\n' "$_root" "${_name:-project}" > "$PRP_DIR/project.json"
+mkdir -p "$PRP_DIR/spikes"
+```
+
+The resolver keys off the main repo, so the file lands in the shared store and stays readable from the main checkout while the spike branch is untouched.
+
+Read `templates/spike-report.md` now (mandatory) and create `$PRP_DIR/spikes/spike-<slug>.md` with its header, `## The question` section, and `**Verdict**: (pending)`. Phase 6 fills in the rest; the hypothesis, kill criteria, and verdict boundaries recorded here are **never edited after this point**. The pending marker keeps an abandoned spike visibly unfinished instead of reading as a report with a missing verdict.
+
+**GATE**: the file exists and contains the hypothesis, kill criteria, and verdict boundaries. Do not build without it.
+
+## Phase 2 — Isolate
+
+Spike code is disposable and often invasive. Keep it away from the working checkout.
+
+Use the prp-worktree skill to create a worktree named `spike/<slug>`, and work there. The branch is the spike's home; it is never merged.
+
+`--here` skips the worktree — use it only when a fresh checkout cannot run the project (gitignored build prerequisites, an expensive bootstrap, a running local stack). It changes how the spike is captured and torn down; see Phase 7. Record in the report that it was used and why.
+
+## Phase 3 — Research
+
+Read only enough to choose a **credible** approach — one a competent engineer would defend. A spike that fails because of a naive approach has proven nothing about the idea.
+
+- Prefer primary sources: official docs, the dependency's actual source, specs, the codebase itself.
+- Use `prp-core:web-researcher` for anything outside the training cutoff, and `prp-core:codebase-analyst` to learn how the relevant subsystem really works before assuming what it allows.
+- Stop when the approach is defensible. Research is not the deliverable here; the build is.
+
+## Phase 4 — Build the falsifier
+
+Build the **smallest artifact that could prove the hypothesis wrong**, then stop.
+
+The shape follows the question, not a catalogue — an interactive demo, a comparison of N implementations against a stated metric, a probe against a real API, a load harness, a type-level sketch, a patched dependency proving a primitive change works. Ask: *what would I have to see to stop believing this?* Build that.
+
+Hold to:
+
+- **Aim at the risk.** Build the part that might fail. Scaffolding, auth, styling, and persistence are not the question — stub them.
+- **No production habits.** No tests, no error handling beyond what keeps it running, no abstractions. Every hour spent making spike code good is an hour not spent learning.
+- **Real inputs.** Real data shapes, real API, real volumes. A spike on synthetic happy-path data proves nothing about production.
+- **Surface the state.** Print or render what the artifact is doing, so the evidence is observable rather than asserted.
+- **Track what got faked.** Every stub is a hole in the proof; the report has to name them.
+
+## Phase 5 — Stress
+
+A spike that only ran the happy path has not been tested — it has been demoed. Attack the claim where it is weakest.
+
+Work the kill criteria from Phase 1 deliberately: push the volume, break the assumption the approach rests on, feed the edge case, pull the dependency. Most spikes earn their keep here.
+
+For evidence standards — what counts as proof, how to make a comparison fair, and the traps that make spikes lie — read `references/evidence.md`.
+
+## Phase 6 — Verdict
+
+**Re-read the kill criteria and verdict boundaries recorded in Phase 1 before choosing — not after.** They were written by someone who had not yet seen these results. That is the only reason they are worth anything.
+
+Reach one verdict:
+
+| Verdict | Meaning |
+|---|---|
+| **PROVEN** | Holds within current constraints. Evidence attached. |
+| **DISPROVEN** | Does not hold. Name the wall it hit and why it is not the approach's fault. |
+| **CONDITIONAL** | Holds only if a named constraint changes. Name the constraint, the cost of changing it, and what else that change would unlock. |
+
+**CONDITIONAL is the verdict most spikes should reach and most reports dodge.** "Impossible" is usually shorthand for "impossible without changing something we were treating as fixed" — a primitive, a schema, a dependency, a product rule. Surfacing that trade is the point: it converts a dead end into a priced decision. Never collapse it into DISPROVEN. Never let it drift into PROVEN by quietly assuming the change is free.
+
+Complete `$PRP_DIR/spikes/spike-<slug>.md` — read `templates/spike-report.md` again (mandatory) and fill every remaining section, replacing `(pending)` with the verdict. Keep every heading; drop only the CONDITIONAL section when the verdict is not CONDITIONAL.
+
+## Phase 7 — Dispose
+
+Commit the spike to its branch, and push it if the repo has a remote. The branch **is** the artifact — the evidence behind the verdict, re-runnable by whoever doubts the result.
+
+- **Never open a PR.** Every other terminal skill in this pack ends in one; this one ends in a verdict.
+- Do not fold spike code into production. A validated approach gets **rewritten** under normal standards, by `prp-plan` and `prp-implement`.
+- Leave the worktree in place if the user may want to poke at it; otherwise tear it down with the prp-worktree skill. The branch survives either way.
+- **Under `--here` there is no spike branch.** Never commit to the branch that was already checked out. Capture the work as a patch — `git diff > "$PRP_DIR/spikes/spike-<slug>.patch"` (add `git diff --cached` and untracked files if either exists) — then restore the checkout to the state it was found in, and record the patch path where the report asks for a branch.
+
+Report to the user: the hypothesis, the verdict, the two or three pieces of evidence that decided it, the branch or patch path, and the report path. Lead with the verdict.
+
+## Gotchas
+
+- **The build phase eats spikes.** Producing something impressive rather than something decisive is the default failure. Return to the hypothesis whenever the next step is unclear.
+- **A working artifact is not a PROVEN hypothesis.** It proves only what it exercised.
+- **Spike effort does not estimate real effort.** Something built in an hour without tests, error handling, or edge cases is not an hour of work. Say this wherever the report could be read as a plan.
+- **Do not let a spike become the implementation.** When the verdict is PROVEN and the code looks decent, the pull to keep going is strong. Stop and hand off.
+
+## Resources
+
+- `references/framing.md` — turning a vague idea into a falsifiable hypothesis with kill criteria; constraint and comparison questions; splitting and sizing
+- `references/evidence.md` — evidence standards, fair comparisons, proving a negative, the traps that make spikes lie (mandatory read in Phase 1 for a comparison spike, before either variant is built; otherwise read in Phase 5)
+- `templates/spike-report.md` — the report to fill (mandatory read in Phase 1 to record the frame, and again in Phase 6 to complete it)

--- a/.claude/skills/prp-spike/references/evidence.md
+++ b/.claude/skills/prp-spike/references/evidence.md
@@ -1,0 +1,67 @@
+# Evidence
+
+A spike's authority comes entirely from its evidence. A confident verdict with weak evidence is worse than no spike — it gets believed.
+
+## Standards
+
+| Counts as evidence | Does not |
+|---|---|
+| Command output actually run, pasted | "This should work" |
+| A measurement, with the conditions it was taken under | A number with no method |
+| An error message hit, with what triggered it | "It would probably fail on..." |
+| Observed behavior of the artifact | Behavior of the artifact as designed |
+| A `file:line` in a real dependency's source | Recollection of how a library behaves |
+| A documented guarantee, cited | An assumed guarantee |
+
+Every claim in the report traces to something observed. Where reasoning fills a gap, mark it as reasoning — the reader needs to know which parts would survive scrutiny.
+
+## "It ran" is not "it works"
+
+A running artifact proves the hypothesis held **under the conditions tried**. The distance between those conditions and production is the real finding, and naming it is the report's honesty test.
+
+Before claiming PROVEN, state plainly:
+
+- **What was stubbed** — every fake is a hole. A spike that mocked the thing it was supposed to test has proven nothing; a spike that mocked the login screen is fine. Know which one this is.
+- **Scale tried vs scale expected** — ten records is not a million. If the volume was not realistic, the volume question is untested, not passed.
+- **Conditions not exercised** — concurrency, failure of a dependency, cold start, hostile input, slow network.
+- **Duration** — anything about leaks, drift, or accumulation is untested by a run that lasted seconds.
+
+## Fair comparison
+
+When the spike compares approaches, the comparison is the experiment and it is easy to rig without meaning to.
+
+- **Fix the metric first.** Before building, name what wins: latency at a percentile, lines of code touched to add a feature, number of concepts a new developer must learn. A metric chosen afterwards will be the one the favourite happens to win.
+- **Vary one thing.** Same data, same hardware, same conditions. An approach also written second, by a more informed author, is not being compared fairly.
+- **Give each approach its best shot.** The failure mode is building the favourite properly and the alternative naively. If one approach is unfamiliar, research it to the same standard before building — a straw man proves nothing.
+- **Repeat measurements.** One run is noise. Discard warmup, run enough times to see the spread, and report the spread rather than the best number.
+- **Report the losers' strengths.** The useful outcome is often "A overall, but B's handling of X is worth stealing." A comparison that only ranks throws away most of what it learned.
+
+Where the metric is taste rather than measurement — how an interaction feels, how an API reads — the artifact's job is to let a human judge, not to decide. Put the variants side by side, make switching trivial, and hand it over. Record whose judgement was applied and on what.
+
+## Proving a negative
+
+DISPROVEN carries a higher burden than PROVEN, because "I could not make it work" and "it cannot work" look identical from the inside.
+
+Before reporting DISPROVEN, establish:
+
+- **The approach was credible** — the way a competent engineer would do it, not the first thing tried.
+- **The obvious alternatives were considered** — and why they fail too, or why they were not tried.
+- **The wall is structural** — a property of the technology, the architecture, or the constraint. If the wall is "this was harder than expected", the finding is a cost estimate, not a disproof.
+- **The failure is reproducible** — the exact command or condition, so the next person can check rather than trust.
+
+Most honest disproofs are actually CONDITIONAL: it cannot work *given something being held fixed*. Name that thing. It is more useful than the disproof.
+
+## Traps
+
+- **Measuring the wrong layer.** A benchmark dominated by JSON serialization says nothing about the database being evaluated. Confirm the measurement is sensitive to the thing under test — change that thing and check the number moves.
+- **Caching.** A second run hitting a warm cache, a memoized result, or a CDN measures the cache. Especially deceptive across variants when one is warmed by the other.
+- **The stub that hid the hard part.** Mocks migrate toward whatever was difficult. Re-read every stub against the hypothesis before concluding.
+- **Synthetic data.** Uniform, clean, small generated data hides exactly the distribution problems, encoding edge cases, and skew that break the real thing.
+- **Confirmation drift.** After investment in an approach, ambiguous results read as success. The pre-committed kill criteria exist for this moment — re-read them before deciding, not after.
+- **The artifact becoming the point.** Time spent polishing something that will be thrown away is time not spent on evidence. Build ugly, learn fast.
+
+## What is still unknown
+
+Every spike ends with an explicit list of what it did not settle. This is not a disclaimer — it bounds the spike's authority and prevents a narrow result being read as a general one.
+
+Include the conditions never exercised, the parts stubbed, the scale untested, and any question the spike raised without answering. A spike that surfaces a better question than it started with has done well; that only lands if the question is written down.

--- a/.claude/skills/prp-spike/references/framing.md
+++ b/.claude/skills/prp-spike/references/framing.md
@@ -1,0 +1,80 @@
+# Framing the Spike
+
+The framing decides whether the spike is worth running. Everything downstream is cheap to redo; this is not.
+
+## The falsifiability test
+
+A hypothesis qualifies when a specific observation would make it false, and that observation is plausible enough to be worth looking for.
+
+Apply two checks:
+
+1. **Name the disproof.** "What would I have to see to stop believing this?" No answer means it is a topic, not a hypothesis.
+2. **Check both outcomes change something.** If PROVEN and DISPROVEN lead to the same next action, the question is not load-bearing. Do not spend a spike on it.
+
+## Vague to falsifiable
+
+| Vague request | Falsifiable hypothesis |
+|---|---|
+| "Can we use X?" | "X can do <specific job> against <our real constraint> without <the thing we fear>." |
+| "Is this fast enough?" | "<Operation> completes within <budget> at <realistic volume> on <representative hardware>." |
+| "Would this feel better?" | "Users can complete <task> in this interaction model without hitting <the confusion we predict>." |
+| "Should we adopt Y?" | "Y handles <the two cases our current thing handles badly> without losing <the case it handles well>." |
+| "Can our schema support Z?" | "Z is representable in the current schema without a migration and without a denormalized write path." |
+
+The pattern: replace the adjective with a threshold, and name the failure being feared. "Fast enough", "clean", "better", "scalable" are all placeholders for a number or a named condition that has not been decided yet. Deciding it is part of the framing, not the build.
+
+## Kill criteria
+
+Write, before building, the observations that would end the spike as DISPROVEN. Good kill criteria are:
+
+- **Observable** — a measurement, an error, a behavior seen, not a feeling.
+- **Pre-committed** — fixed before results exist. A threshold chosen after seeing the number is not a threshold.
+- **Plausible** — at least one must be a real possibility. If every kill criterion is far-fetched, the hypothesis is trivially true and the spike is theatre.
+
+Where a threshold is genuinely unknown, say so explicitly and record the number the spike produces as a **finding** rather than a pass/fail. A spike that establishes the baseline is legitimate; one that invents a threshold to clear afterwards is not.
+
+## Question archetypes
+
+The question type shapes what evidence will be needed. It does not dictate what to build — that follows from what would falsify the claim.
+
+**Feasibility** — can this be done here at all? Evidence is a working (ugly) path through the hardest part. Aim the build at the step most likely to be impossible, not the first step.
+
+**Fit** — does this belong in our stack? Feasibility is usually not in doubt; the question is what it costs in friction. Evidence is the integration seam actually built: where it fights the existing abstractions, what it forces elsewhere, what it would make harder forever.
+
+**Constraint / primitive** — see below.
+
+**Comparison** — which approach wins? The metric that decides it is fixed and recorded during framing, before any variant exists; a metric chosen afterwards will be the one the favourite happens to win. The build then has to give every approach its best shot, or it proves nothing.
+
+## Constraint questions
+
+"Is it worth changing X to allow Y" is a different question from "is Y possible", and it is the one most often mis-framed as the other. Treat the constraint as the variable.
+
+Frame it as: **"Y is impossible under <constraint C>, and possible under <specific relaxation of C>."** Then the spike has two jobs — demonstrate the wall, and demonstrate that moving it actually helps. Skipping the first produces a proposal to change a primitive with no evidence the primitive was the obstacle.
+
+The report has to price the change, not just prove it works:
+
+- **What exactly changes** — the primitive, schema, dependency, or product rule, stated precisely enough to estimate.
+- **Blast radius** — what else depends on the current behavior, and what breaks or needs migrating.
+- **What else it unlocks** — a constraint blocking one feature usually blocks others. This is often what tips the decision, and a spike scoped to one feature is the thing most likely to miss it.
+- **The reversible option** — whether the same result can be had behind a flag, an adapter, or a narrower change. Usually worth one attempt before recommending surgery on a primitive.
+
+A constraint spike that reports "we should change C" without blast radius has done half the work. The decision is a trade, so the evidence must cover both sides.
+
+## Splitting
+
+When an idea carries several independent risks, one spike answering all of them is slow and hard to read. Split into 2–5 questions, each independently falsifiable, and **run the riskiest first** — disproving it makes the rest unnecessary.
+
+Order by *probability of failure*, not by build order or by which is easiest. The cheapest spike is the one never run because an earlier one closed the path.
+
+Signals that a spike is really several:
+- The hypothesis needs "and" between two technical claims.
+- Different parts would be disproven by unrelated evidence.
+- One part is nearly certain and another is a coin flip — the certain part is padding.
+
+## Sizing
+
+The spike ends when the question is answered — not at a time box, and not when the artifact feels finished.
+
+- **Answered early is done.** If the first thing built disproves the hypothesis in twenty minutes, that is the ideal outcome. Do not keep building to justify the exercise.
+- **No end in sight means re-frame.** A spike that keeps growing is usually answering an unfalsifiable question, or several at once. Return here and split.
+- **Blocked on access, not knowledge, is not a spike.** Missing credentials, a licence, or a decision only a human can make is a blocker to report, not a thing to work around with a mock — a mock of the unknown part proves nothing about it.

--- a/.claude/skills/prp-spike/templates/spike-report.md
+++ b/.claude/skills/prp-spike/templates/spike-report.md
@@ -1,0 +1,80 @@
+# Spike Report Template
+
+Written in two passes. In **Phase 1**, create the file with the header (verdict `(pending)`) and `## The question` filled in — that section is the pre-commitment and is never edited afterwards. In **Phase 6**, replace `(pending)` with the verdict and fill everything else.
+
+Lead with the verdict — the reader wants the decision first and the working second.
+
+Drop the CONDITIONAL section when the verdict is not CONDITIONAL. Keep every other section: the ones that bound the result are the ones a reader most needs and an author most wants to skip.
+
+---
+
+```markdown
+# Spike: {question in a few words}
+
+**Verdict**: {(pending) until Phase 6 — then PROVEN | DISPROVEN | CONDITIONAL}
+**Hypothesis**: {the falsifiable claim, as committed before the build}
+**Date**: {YYYY-MM-DD}
+**Evidence**: `{spike/<slug>}` {or, under --here: `spikes/spike-<slug>.patch` — no branch}
+
+## Verdict
+
+{2–4 sentences. What was established, and the single piece of evidence that decided it. If CONDITIONAL, name the constraint here — do not make the reader hunt for it.}
+
+## The question
+
+{Why this was worth a spike: the decision waiting on it, and what each outcome would change.}
+
+**Kill criteria** (committed before building):
+- {observation that would have disproven it}
+- {…}
+
+**Verdict boundaries** (committed before building):
+- PROVEN if {…} · CONDITIONAL if {…} · DISPROVEN if {…}
+
+{In Phase 6: which kill criteria fired, or that none did.}
+
+## What was built
+
+{The artifact, in a few lines: what it does, aimed at which risk. Where it lives on the branch, and the command to run it.}
+
+**Approach**: {the approach taken and why it is a credible one — what a competent engineer would do here.}
+
+## Evidence
+
+{Observed results only. Commands run with their output, measurements with the conditions they were taken under, errors hit with what triggered them. Where reasoning fills a gap, mark it as reasoning.}
+
+{For a comparison: the metric fixed before building, the conditions held equal, results including spread, and what the losing approaches did better.}
+
+## The constraint
+
+**What must change**: {the primitive, schema, dependency, or product rule — precisely enough to estimate}
+
+**Evidence it is the obstacle**: {the wall demonstrated, and that moving it helps}
+
+**Blast radius**: {what depends on current behavior; what breaks or needs migrating}
+
+**Also unlocks**: {other things this constraint currently blocks — often what tips the decision}
+
+**Cheaper option tried**: {flag, adapter, or narrower change — and why it does or does not suffice}
+
+## Limits of this result
+
+- **Stubbed**: {every fake, and whether any of them covered part of the question}
+- **Scale tried**: {vs the scale expected in production}
+- **Not exercised**: {concurrency, dependency failure, cold start, hostile input, duration}
+
+## Still unknown
+
+- {question this spike did not settle}
+- {question this spike raised}
+
+## Recommendation
+
+{What to do next, and what NOT to do. If PROVEN: the plan-and-implement path, and the parts of the real build this spike did not touch. If DISPROVEN: the path now closed, and what to try instead. If CONDITIONAL: the trade, stated as a decision someone can make.}
+
+**Effort**: this spike took {duration} without tests, error handling, or edge cases. That is not an estimate for the real build. {What the real one additionally needs.}
+
+## Reproducing
+
+{Branch — or patch path and the commit it applies to, under --here. How to run it, what to look at. This is the evidence: anyone doubting the verdict should be able to check it rather than trust it.}
+```

--- a/plugins/prp-core/skills/prp-spike/SKILL.md
+++ b/plugins/prp-core/skills/prp-spike/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: prp-spike
+description: Prove or disprove an idea by building the smallest throwaway artifact that could falsify it, in an isolated worktree, ending in a PROVEN / DISPROVEN / CONDITIONAL verdict backed by evidence - never a PR. Use when the user wants to "spike this", "build a proof of concept", "POC this", "prototype it to find out", asks "is this possible", "is this feasible", "does this fit our stack", or "would it be worth changing X to allow Y" and wants it settled by building rather than by analysis, wants to compare approaches on evidence before picking one, or invokes /prp-spike.
+argument-hint: "<idea or question> [--here]"
+---
+
+# PRP Spike — Prove or Disprove
+
+Settle an open question by building the smallest thing that could prove it **wrong**. The deliverable is a verdict backed by evidence, not shippable code.
+
+**Input**: $ARGUMENTS (if absent, take the question from the conversation).
+
+## When to use
+
+- **Feasibility** — can this be built at all, here, with what we have?
+- **Fit** — does this sit naturally in our stack, or fight it the whole way?
+- **Cost of admission** — what would have to change (a primitive, an abstraction, a product constraint) to make it possible, and is that trade worth it?
+- **Choice** — which of several approaches survives contact with the real constraints?
+
+Not for work whose feasibility is already settled — that is `prp-plan` then `prp-implement`. Not for something already broken — that is `prp-debug`.
+
+## The contract
+
+1. A spike answers **one falsifiable question**. No falsifiable question, no spike.
+2. Kill criteria are written **before** the build. Deciding what counts as failure after seeing results turns a spike into a rationalization.
+3. **DISPROVEN is a success.** It bought a decision with evidence and closed a path that would otherwise have cost weeks.
+4. Spike code is throwaway by construction and **never opens a PR**.
+
+## Phase 1 — Frame
+
+Convert the request into a claim that can fail, and fix the kill criteria before touching code.
+
+Produce four things:
+
+- **Hypothesis** — one sentence, falsifiable, specific enough that two people would agree on whether it held.
+- **Slug** — 2–4 lowercase hyphenated words from the hypothesis. It names the branch, the worktree, and the report file; derive it once here and reuse it everywhere.
+- **Kill criteria** — the specific observations that would end this as DISPROVEN, fixed now rather than after results exist.
+- **Boundaries between verdicts** — what separates PROVEN from CONDITIONAL, and CONDITIONAL from DISPROVEN. The kill criteria say what failure looks like; this says which *kind* of failure it is. Deciding that boundary after seeing results is how CONDITIONAL gets rounded to whichever verdict is more convenient.
+
+If the idea carries several independent risks, split it and spike the **riskiest first** — a cheap disproof there saves the rest. One spike run answers one question: take the riskiest here, and list the rest in the report's Recommendation as follow-up spikes. For the framing craft (vague-to-falsifiable rewrites, constraint questions, splitting, sizing), read `references/framing.md`.
+
+If the spike compares approaches, read `references/evidence.md` → **Fair comparison now**. The winning metric must be fixed and recorded here, before either variant exists — a metric chosen afterwards will be the one the favourite happens to win.
+
+State the frame back to the user. When running interactively, confirm an ambiguous hypothesis before building — a spike that answers the wrong question is total waste, and framing is the cheapest thing to correct. When running unattended, record the interpretation chosen and the alternatives rejected, and proceed.
+
+### Record the frame before building
+
+Pre-commitment only counts if it outlives the conversation. Write the frame to disk now — a transcript does not survive compaction, and an agent that has seen its results can reconstruct criteria that flatter them.
+
+```bash
+# --- PRP store resolver (canonical; keep byte-identical across skills) ---
+_gd="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"
+case "$_gd" in */.git) _root="${_gd%/.git}" ;; "") _root="$PWD" ;; *) _root="$_gd" ;; esac
+_root="$(cd "$_root" && pwd -P)"
+_name="$(basename "$_root" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | sed 's/^-*//;s/-*$//')"
+PRP_DIR="${PRP_HOME:-$HOME/.prp}/${_name:-project}-$(printf %s "$_root" | git hash-object --stdin | cut -c1-8)"
+mkdir -p "$PRP_DIR"; [ -f "$PRP_DIR/project.json" ] || printf '{"path": "%s", "name": "%s"}\n' "$_root" "${_name:-project}" > "$PRP_DIR/project.json"
+mkdir -p "$PRP_DIR/spikes"
+```
+
+The resolver keys off the main repo, so the file lands in the shared store and stays readable from the main checkout while the spike branch is untouched.
+
+Read `templates/spike-report.md` now (mandatory) and create `$PRP_DIR/spikes/spike-<slug>.md` with its header, `## The question` section, and `**Verdict**: (pending)`. Phase 6 fills in the rest; the hypothesis, kill criteria, and verdict boundaries recorded here are **never edited after this point**. The pending marker keeps an abandoned spike visibly unfinished instead of reading as a report with a missing verdict.
+
+**GATE**: the file exists and contains the hypothesis, kill criteria, and verdict boundaries. Do not build without it.
+
+## Phase 2 — Isolate
+
+Spike code is disposable and often invasive. Keep it away from the working checkout.
+
+Use the prp-worktree skill to create a worktree named `spike/<slug>`, and work there. The branch is the spike's home; it is never merged.
+
+`--here` skips the worktree — use it only when a fresh checkout cannot run the project (gitignored build prerequisites, an expensive bootstrap, a running local stack). It changes how the spike is captured and torn down; see Phase 7. Record in the report that it was used and why.
+
+## Phase 3 — Research
+
+Read only enough to choose a **credible** approach — one a competent engineer would defend. A spike that fails because of a naive approach has proven nothing about the idea.
+
+- Prefer primary sources: official docs, the dependency's actual source, specs, the codebase itself.
+- Use `prp-core:web-researcher` for anything outside the training cutoff, and `prp-core:codebase-analyst` to learn how the relevant subsystem really works before assuming what it allows.
+- Stop when the approach is defensible. Research is not the deliverable here; the build is.
+
+## Phase 4 — Build the falsifier
+
+Build the **smallest artifact that could prove the hypothesis wrong**, then stop.
+
+The shape follows the question, not a catalogue — an interactive demo, a comparison of N implementations against a stated metric, a probe against a real API, a load harness, a type-level sketch, a patched dependency proving a primitive change works. Ask: *what would I have to see to stop believing this?* Build that.
+
+Hold to:
+
+- **Aim at the risk.** Build the part that might fail. Scaffolding, auth, styling, and persistence are not the question — stub them.
+- **No production habits.** No tests, no error handling beyond what keeps it running, no abstractions. Every hour spent making spike code good is an hour not spent learning.
+- **Real inputs.** Real data shapes, real API, real volumes. A spike on synthetic happy-path data proves nothing about production.
+- **Surface the state.** Print or render what the artifact is doing, so the evidence is observable rather than asserted.
+- **Track what got faked.** Every stub is a hole in the proof; the report has to name them.
+
+## Phase 5 — Stress
+
+A spike that only ran the happy path has not been tested — it has been demoed. Attack the claim where it is weakest.
+
+Work the kill criteria from Phase 1 deliberately: push the volume, break the assumption the approach rests on, feed the edge case, pull the dependency. Most spikes earn their keep here.
+
+For evidence standards — what counts as proof, how to make a comparison fair, and the traps that make spikes lie — read `references/evidence.md`.
+
+## Phase 6 — Verdict
+
+**Re-read the kill criteria and verdict boundaries recorded in Phase 1 before choosing — not after.** They were written by someone who had not yet seen these results. That is the only reason they are worth anything.
+
+Reach one verdict:
+
+| Verdict | Meaning |
+|---|---|
+| **PROVEN** | Holds within current constraints. Evidence attached. |
+| **DISPROVEN** | Does not hold. Name the wall it hit and why it is not the approach's fault. |
+| **CONDITIONAL** | Holds only if a named constraint changes. Name the constraint, the cost of changing it, and what else that change would unlock. |
+
+**CONDITIONAL is the verdict most spikes should reach and most reports dodge.** "Impossible" is usually shorthand for "impossible without changing something we were treating as fixed" — a primitive, a schema, a dependency, a product rule. Surfacing that trade is the point: it converts a dead end into a priced decision. Never collapse it into DISPROVEN. Never let it drift into PROVEN by quietly assuming the change is free.
+
+Complete `$PRP_DIR/spikes/spike-<slug>.md` — read `templates/spike-report.md` again (mandatory) and fill every remaining section, replacing `(pending)` with the verdict. Keep every heading; drop only the CONDITIONAL section when the verdict is not CONDITIONAL.
+
+## Phase 7 — Dispose
+
+Commit the spike to its branch, and push it if the repo has a remote. The branch **is** the artifact — the evidence behind the verdict, re-runnable by whoever doubts the result.
+
+- **Never open a PR.** Every other terminal skill in this pack ends in one; this one ends in a verdict.
+- Do not fold spike code into production. A validated approach gets **rewritten** under normal standards, by `prp-plan` and `prp-implement`.
+- Leave the worktree in place if the user may want to poke at it; otherwise tear it down with the prp-worktree skill. The branch survives either way.
+- **Under `--here` there is no spike branch.** Never commit to the branch that was already checked out. Capture the work as a patch — `git diff > "$PRP_DIR/spikes/spike-<slug>.patch"` (add `git diff --cached` and untracked files if either exists) — then restore the checkout to the state it was found in, and record the patch path where the report asks for a branch.
+
+Report to the user: the hypothesis, the verdict, the two or three pieces of evidence that decided it, the branch or patch path, and the report path. Lead with the verdict.
+
+## Gotchas
+
+- **The build phase eats spikes.** Producing something impressive rather than something decisive is the default failure. Return to the hypothesis whenever the next step is unclear.
+- **A working artifact is not a PROVEN hypothesis.** It proves only what it exercised.
+- **Spike effort does not estimate real effort.** Something built in an hour without tests, error handling, or edge cases is not an hour of work. Say this wherever the report could be read as a plan.
+- **Do not let a spike become the implementation.** When the verdict is PROVEN and the code looks decent, the pull to keep going is strong. Stop and hand off.
+
+## Resources
+
+- `references/framing.md` — turning a vague idea into a falsifiable hypothesis with kill criteria; constraint and comparison questions; splitting and sizing
+- `references/evidence.md` — evidence standards, fair comparisons, proving a negative, the traps that make spikes lie (mandatory read in Phase 1 for a comparison spike, before either variant is built; otherwise read in Phase 5)
+- `templates/spike-report.md` — the report to fill (mandatory read in Phase 1 to record the frame, and again in Phase 6 to complete it)

--- a/plugins/prp-core/skills/prp-spike/references/evidence.md
+++ b/plugins/prp-core/skills/prp-spike/references/evidence.md
@@ -1,0 +1,67 @@
+# Evidence
+
+A spike's authority comes entirely from its evidence. A confident verdict with weak evidence is worse than no spike — it gets believed.
+
+## Standards
+
+| Counts as evidence | Does not |
+|---|---|
+| Command output actually run, pasted | "This should work" |
+| A measurement, with the conditions it was taken under | A number with no method |
+| An error message hit, with what triggered it | "It would probably fail on..." |
+| Observed behavior of the artifact | Behavior of the artifact as designed |
+| A `file:line` in a real dependency's source | Recollection of how a library behaves |
+| A documented guarantee, cited | An assumed guarantee |
+
+Every claim in the report traces to something observed. Where reasoning fills a gap, mark it as reasoning — the reader needs to know which parts would survive scrutiny.
+
+## "It ran" is not "it works"
+
+A running artifact proves the hypothesis held **under the conditions tried**. The distance between those conditions and production is the real finding, and naming it is the report's honesty test.
+
+Before claiming PROVEN, state plainly:
+
+- **What was stubbed** — every fake is a hole. A spike that mocked the thing it was supposed to test has proven nothing; a spike that mocked the login screen is fine. Know which one this is.
+- **Scale tried vs scale expected** — ten records is not a million. If the volume was not realistic, the volume question is untested, not passed.
+- **Conditions not exercised** — concurrency, failure of a dependency, cold start, hostile input, slow network.
+- **Duration** — anything about leaks, drift, or accumulation is untested by a run that lasted seconds.
+
+## Fair comparison
+
+When the spike compares approaches, the comparison is the experiment and it is easy to rig without meaning to.
+
+- **Fix the metric first.** Before building, name what wins: latency at a percentile, lines of code touched to add a feature, number of concepts a new developer must learn. A metric chosen afterwards will be the one the favourite happens to win.
+- **Vary one thing.** Same data, same hardware, same conditions. An approach also written second, by a more informed author, is not being compared fairly.
+- **Give each approach its best shot.** The failure mode is building the favourite properly and the alternative naively. If one approach is unfamiliar, research it to the same standard before building — a straw man proves nothing.
+- **Repeat measurements.** One run is noise. Discard warmup, run enough times to see the spread, and report the spread rather than the best number.
+- **Report the losers' strengths.** The useful outcome is often "A overall, but B's handling of X is worth stealing." A comparison that only ranks throws away most of what it learned.
+
+Where the metric is taste rather than measurement — how an interaction feels, how an API reads — the artifact's job is to let a human judge, not to decide. Put the variants side by side, make switching trivial, and hand it over. Record whose judgement was applied and on what.
+
+## Proving a negative
+
+DISPROVEN carries a higher burden than PROVEN, because "I could not make it work" and "it cannot work" look identical from the inside.
+
+Before reporting DISPROVEN, establish:
+
+- **The approach was credible** — the way a competent engineer would do it, not the first thing tried.
+- **The obvious alternatives were considered** — and why they fail too, or why they were not tried.
+- **The wall is structural** — a property of the technology, the architecture, or the constraint. If the wall is "this was harder than expected", the finding is a cost estimate, not a disproof.
+- **The failure is reproducible** — the exact command or condition, so the next person can check rather than trust.
+
+Most honest disproofs are actually CONDITIONAL: it cannot work *given something being held fixed*. Name that thing. It is more useful than the disproof.
+
+## Traps
+
+- **Measuring the wrong layer.** A benchmark dominated by JSON serialization says nothing about the database being evaluated. Confirm the measurement is sensitive to the thing under test — change that thing and check the number moves.
+- **Caching.** A second run hitting a warm cache, a memoized result, or a CDN measures the cache. Especially deceptive across variants when one is warmed by the other.
+- **The stub that hid the hard part.** Mocks migrate toward whatever was difficult. Re-read every stub against the hypothesis before concluding.
+- **Synthetic data.** Uniform, clean, small generated data hides exactly the distribution problems, encoding edge cases, and skew that break the real thing.
+- **Confirmation drift.** After investment in an approach, ambiguous results read as success. The pre-committed kill criteria exist for this moment — re-read them before deciding, not after.
+- **The artifact becoming the point.** Time spent polishing something that will be thrown away is time not spent on evidence. Build ugly, learn fast.
+
+## What is still unknown
+
+Every spike ends with an explicit list of what it did not settle. This is not a disclaimer — it bounds the spike's authority and prevents a narrow result being read as a general one.
+
+Include the conditions never exercised, the parts stubbed, the scale untested, and any question the spike raised without answering. A spike that surfaces a better question than it started with has done well; that only lands if the question is written down.

--- a/plugins/prp-core/skills/prp-spike/references/framing.md
+++ b/plugins/prp-core/skills/prp-spike/references/framing.md
@@ -1,0 +1,80 @@
+# Framing the Spike
+
+The framing decides whether the spike is worth running. Everything downstream is cheap to redo; this is not.
+
+## The falsifiability test
+
+A hypothesis qualifies when a specific observation would make it false, and that observation is plausible enough to be worth looking for.
+
+Apply two checks:
+
+1. **Name the disproof.** "What would I have to see to stop believing this?" No answer means it is a topic, not a hypothesis.
+2. **Check both outcomes change something.** If PROVEN and DISPROVEN lead to the same next action, the question is not load-bearing. Do not spend a spike on it.
+
+## Vague to falsifiable
+
+| Vague request | Falsifiable hypothesis |
+|---|---|
+| "Can we use X?" | "X can do <specific job> against <our real constraint> without <the thing we fear>." |
+| "Is this fast enough?" | "<Operation> completes within <budget> at <realistic volume> on <representative hardware>." |
+| "Would this feel better?" | "Users can complete <task> in this interaction model without hitting <the confusion we predict>." |
+| "Should we adopt Y?" | "Y handles <the two cases our current thing handles badly> without losing <the case it handles well>." |
+| "Can our schema support Z?" | "Z is representable in the current schema without a migration and without a denormalized write path." |
+
+The pattern: replace the adjective with a threshold, and name the failure being feared. "Fast enough", "clean", "better", "scalable" are all placeholders for a number or a named condition that has not been decided yet. Deciding it is part of the framing, not the build.
+
+## Kill criteria
+
+Write, before building, the observations that would end the spike as DISPROVEN. Good kill criteria are:
+
+- **Observable** — a measurement, an error, a behavior seen, not a feeling.
+- **Pre-committed** — fixed before results exist. A threshold chosen after seeing the number is not a threshold.
+- **Plausible** — at least one must be a real possibility. If every kill criterion is far-fetched, the hypothesis is trivially true and the spike is theatre.
+
+Where a threshold is genuinely unknown, say so explicitly and record the number the spike produces as a **finding** rather than a pass/fail. A spike that establishes the baseline is legitimate; one that invents a threshold to clear afterwards is not.
+
+## Question archetypes
+
+The question type shapes what evidence will be needed. It does not dictate what to build — that follows from what would falsify the claim.
+
+**Feasibility** — can this be done here at all? Evidence is a working (ugly) path through the hardest part. Aim the build at the step most likely to be impossible, not the first step.
+
+**Fit** — does this belong in our stack? Feasibility is usually not in doubt; the question is what it costs in friction. Evidence is the integration seam actually built: where it fights the existing abstractions, what it forces elsewhere, what it would make harder forever.
+
+**Constraint / primitive** — see below.
+
+**Comparison** — which approach wins? The metric that decides it is fixed and recorded during framing, before any variant exists; a metric chosen afterwards will be the one the favourite happens to win. The build then has to give every approach its best shot, or it proves nothing.
+
+## Constraint questions
+
+"Is it worth changing X to allow Y" is a different question from "is Y possible", and it is the one most often mis-framed as the other. Treat the constraint as the variable.
+
+Frame it as: **"Y is impossible under <constraint C>, and possible under <specific relaxation of C>."** Then the spike has two jobs — demonstrate the wall, and demonstrate that moving it actually helps. Skipping the first produces a proposal to change a primitive with no evidence the primitive was the obstacle.
+
+The report has to price the change, not just prove it works:
+
+- **What exactly changes** — the primitive, schema, dependency, or product rule, stated precisely enough to estimate.
+- **Blast radius** — what else depends on the current behavior, and what breaks or needs migrating.
+- **What else it unlocks** — a constraint blocking one feature usually blocks others. This is often what tips the decision, and a spike scoped to one feature is the thing most likely to miss it.
+- **The reversible option** — whether the same result can be had behind a flag, an adapter, or a narrower change. Usually worth one attempt before recommending surgery on a primitive.
+
+A constraint spike that reports "we should change C" without blast radius has done half the work. The decision is a trade, so the evidence must cover both sides.
+
+## Splitting
+
+When an idea carries several independent risks, one spike answering all of them is slow and hard to read. Split into 2–5 questions, each independently falsifiable, and **run the riskiest first** — disproving it makes the rest unnecessary.
+
+Order by *probability of failure*, not by build order or by which is easiest. The cheapest spike is the one never run because an earlier one closed the path.
+
+Signals that a spike is really several:
+- The hypothesis needs "and" between two technical claims.
+- Different parts would be disproven by unrelated evidence.
+- One part is nearly certain and another is a coin flip — the certain part is padding.
+
+## Sizing
+
+The spike ends when the question is answered — not at a time box, and not when the artifact feels finished.
+
+- **Answered early is done.** If the first thing built disproves the hypothesis in twenty minutes, that is the ideal outcome. Do not keep building to justify the exercise.
+- **No end in sight means re-frame.** A spike that keeps growing is usually answering an unfalsifiable question, or several at once. Return here and split.
+- **Blocked on access, not knowledge, is not a spike.** Missing credentials, a licence, or a decision only a human can make is a blocker to report, not a thing to work around with a mock — a mock of the unknown part proves nothing about it.

--- a/plugins/prp-core/skills/prp-spike/templates/spike-report.md
+++ b/plugins/prp-core/skills/prp-spike/templates/spike-report.md
@@ -1,0 +1,80 @@
+# Spike Report Template
+
+Written in two passes. In **Phase 1**, create the file with the header (verdict `(pending)`) and `## The question` filled in — that section is the pre-commitment and is never edited afterwards. In **Phase 6**, replace `(pending)` with the verdict and fill everything else.
+
+Lead with the verdict — the reader wants the decision first and the working second.
+
+Drop the CONDITIONAL section when the verdict is not CONDITIONAL. Keep every other section: the ones that bound the result are the ones a reader most needs and an author most wants to skip.
+
+---
+
+```markdown
+# Spike: {question in a few words}
+
+**Verdict**: {(pending) until Phase 6 — then PROVEN | DISPROVEN | CONDITIONAL}
+**Hypothesis**: {the falsifiable claim, as committed before the build}
+**Date**: {YYYY-MM-DD}
+**Evidence**: `{spike/<slug>}` {or, under --here: `spikes/spike-<slug>.patch` — no branch}
+
+## Verdict
+
+{2–4 sentences. What was established, and the single piece of evidence that decided it. If CONDITIONAL, name the constraint here — do not make the reader hunt for it.}
+
+## The question
+
+{Why this was worth a spike: the decision waiting on it, and what each outcome would change.}
+
+**Kill criteria** (committed before building):
+- {observation that would have disproven it}
+- {…}
+
+**Verdict boundaries** (committed before building):
+- PROVEN if {…} · CONDITIONAL if {…} · DISPROVEN if {…}
+
+{In Phase 6: which kill criteria fired, or that none did.}
+
+## What was built
+
+{The artifact, in a few lines: what it does, aimed at which risk. Where it lives on the branch, and the command to run it.}
+
+**Approach**: {the approach taken and why it is a credible one — what a competent engineer would do here.}
+
+## Evidence
+
+{Observed results only. Commands run with their output, measurements with the conditions they were taken under, errors hit with what triggered them. Where reasoning fills a gap, mark it as reasoning.}
+
+{For a comparison: the metric fixed before building, the conditions held equal, results including spread, and what the losing approaches did better.}
+
+## The constraint
+
+**What must change**: {the primitive, schema, dependency, or product rule — precisely enough to estimate}
+
+**Evidence it is the obstacle**: {the wall demonstrated, and that moving it helps}
+
+**Blast radius**: {what depends on current behavior; what breaks or needs migrating}
+
+**Also unlocks**: {other things this constraint currently blocks — often what tips the decision}
+
+**Cheaper option tried**: {flag, adapter, or narrower change — and why it does or does not suffice}
+
+## Limits of this result
+
+- **Stubbed**: {every fake, and whether any of them covered part of the question}
+- **Scale tried**: {vs the scale expected in production}
+- **Not exercised**: {concurrency, dependency failure, cold start, hostile input, duration}
+
+## Still unknown
+
+- {question this spike did not settle}
+- {question this spike raised}
+
+## Recommendation
+
+{What to do next, and what NOT to do. If PROVEN: the plan-and-implement path, and the parts of the real build this spike did not touch. If DISPROVEN: the path now closed, and what to try instead. If CONDITIONAL: the trade, stated as a decision someone can make.}
+
+**Effort**: this spike took {duration} without tests, error handling, or edge cases. That is not an estimate for the real build. {What the real one additionally needs.}
+
+## Reproducing
+
+{Branch — or patch path and the commit it applies to, under --here. How to run it, what to look at. This is the evidence: anyone doubting the verdict should be able to check it rather than trust it.}
+```


### PR DESCRIPTION
Adds `prp-spike`, the skill for the question that comes before planning: is this possible here, and what would it cost to make it possible.

The pack could plan, implement, review and debug. That work was falling into `prp-plan`, which assumes feasibility is settled and will happily produce a plan for something nobody has established can be built.

A spike answers **one falsifiable question** by building the smallest artifact that could prove it wrong, in a worktree, and ends in a verdict rather than a PR.

## Design

**`CONDITIONAL` is a peer verdict, not a shade of `DISPROVEN`.** "Impossible" is usually shorthand for "impossible without changing something we were treating as fixed" — a primitive, a schema, a dependency, a product rule. The skill makes that trade the deliverable: the constraint stated precisely enough to estimate, evidence it is actually the obstacle (demonstrate the wall *and* that moving it helps), blast radius, and what else moving it would unlock — which is often what tips the decision, and what a spike scoped to one feature most reliably misses.

**Kill criteria are written to disk in Phase 1, before the build, and never edited after.** Pre-commitment that lives only in the transcript does not survive compaction, and an agent that has seen its own results can reconstruct criteria that flatter them. Phase 6 re-reads the recorded frame before choosing a verdict — "they were written by someone who had not yet seen these results; that is the only reason they are worth anything."

**Artifact shape is not prescribed.** No taxonomy of prototype types. Phase 4 asks what would have to be seen to stop believing the hypothesis, and builds that.

**`DISPROVEN` is a success**, and carries the higher burden of proof: a credible approach, the obvious alternatives considered, and a structural wall rather than "this was harder than expected".

**Never opens a PR.** Every other terminal skill in the pack does, so the prohibition is stated rather than left implied.

## Files

- `SKILL.md` — 7 phases (Frame / Isolate / Research / Build the falsifier / Stress / Verdict / Dispose), 1,761 words
- `references/framing.md` — falsifiability test, vague-to-falsifiable rewrites, kill-criteria quality, constraint questions, splitting by probability of failure, sizing
- `references/evidence.md` — evidence standards, "it ran" vs "it works", fair comparison, proving a negative, the traps that make spikes lie
- `templates/spike-report.md` — written in two passes: Phase 1 records the pre-commitment, Phase 6 the verdict

## Validation

Meta-skill gates 1–7. Reviewed by `plugin-dev:skill-reviewer`; all twelve findings applied — slug derivation, durable Phase 1 gate, `--here` disposal via patch (it previously contradicted Phase 7, which pushes to a spike branch that does not exist under `--here`), template arrow leaking into generated reports, a nested reference chain that put the fair-comparison rules out of reach until after both variants were built, and body/reference duplication.

Not yet exercised end-to-end on a real spike — that is the remaining gate.

`python3 scripts/sync_plugin.py --check` passes; plugin and Codex renders included.