### PR TITLE
fix(prp-orchestrate): the body still said prp-review needs no worktree

### DIFF
--- a/.agents/skills/prp-orchestrate/SKILL.md
+++ b/.agents/skills/prp-orchestrate/SKILL.md
@@ -37,7 +37,7 @@ mkdir -p "$PRP_DIR"; [ -f "$PRP_DIR/project.json" ] || printf '{"path": "%s", "n
    - Issue → `prp-issue` (investigate, then fix)
    - Feature with an existing plan → `prp-implement` (+ `prp-pr`)
    - Feature from a description → `prp-loop`, or staged `prp-plan` → gate → `prp-implement` when the user should see plans before code
-   - Review-only / research-only → `prp-review` / `prp-codebase-question` (plain background agents, no worktree)
+   - Review-only → `prp-review` (worktree — it runs `gh pr checkout`); research-only → `prp-codebase-question` (plain background agent)
 3. Map dependencies and conflict risk: predict the files each workstream touches. Disjoint → parallel; overlapping → serialize or merge into one workstream.
 4. Size the batch. Default `--max-parallel 3`; raise only when workstreams are provably disjoint. More parallel agents = more merge surface and more gates.
 
@@ -62,8 +62,9 @@ Worktree agents branch from one tip while PRs diff against the other, and **both
 
 Launch each workstream as a **background agent** via your delegation tool — see `references/launching.md` for the exact call shape and prompt template (read it before the first launch of a run):
 
-- **PR-producing work** → background agent with **worktree isolation**: the agent gets its own checkout, creates its branch, commits, pushes, opens the PR.
-- **Read-only work** (review, research, triage) → plain background agents, several in one message so they run concurrently.
+- **Worktree isolation is the default** — every workstream that touches the working tree gets its own checkout. The test is *"does it touch the working tree"*, not *"does it open a PR"*: `prp-review` looks read-only but runs `gh pr checkout`, so it gets a worktree too.
+- **PR-producing work** → background agent, worktree-isolated: the agent creates its branch, commits, pushes, opens the PR.
+- **Store-only work** — reads files and writes to the PRP store (`prp-codebase-question`, `prp-debug`, `prp-plan`, `prp-prd`) → plain background agents, several in one message so they run concurrently.
 - Record each agent's ID/name and workstream row in the run file at launch. Respect `--max-parallel`: queue the rest, launch as slots free.
 
 Prompts must be self-sufficient (agents inherit nothing from this conversation) and must end with the escalation rule: *if blocked on a decision only a human can make, stop and report the blocker* — the orchestrator relays it to a gate and resumes the same agent via a follow-up message with the answer, context intact.

--- a/.claude/skills/prp-orchestrate/SKILL.md
+++ b/.claude/skills/prp-orchestrate/SKILL.md
@@ -36,7 +36,7 @@ mkdir -p "$PRP_DIR"; [ -f "$PRP_DIR/project.json" ] || printf '{"path": "%s", "n
    - Issue → `prp-issue` (investigate, then fix)
    - Feature with an existing plan → `prp-implement` (+ `prp-pr`)
    - Feature from a description → `prp-loop`, or staged `prp-plan` → gate → `prp-implement` when the user should see plans before code
-   - Review-only / research-only → `prp-review` / `prp-codebase-question` (plain background agents, no worktree)
+   - Review-only → `prp-review` (worktree — it runs `gh pr checkout`); research-only → `prp-codebase-question` (plain background agent)
 3. Map dependencies and conflict risk: predict the files each workstream touches. Disjoint → parallel; overlapping → serialize or merge into one workstream.
 4. Size the batch. Default `--max-parallel 3`; raise only when workstreams are provably disjoint. More parallel agents = more merge surface and more gates.
 
@@ -61,8 +61,9 @@ Worktree agents branch from one tip while PRs diff against the other, and **both
 
 Launch each workstream as a **background agent** via the Agent/Task tool — see `references/launching.md` for the exact call shape and prompt template (read it before the first launch of a run):
 
-- **PR-producing work** → background agent with **worktree isolation**: the agent gets its own checkout, creates its branch, commits, pushes, opens the PR.
-- **Read-only work** (review, research, triage) → plain background agents, several in one message so they run concurrently.
+- **Worktree isolation is the default** — every workstream that touches the working tree gets its own checkout. The test is *"does it touch the working tree"*, not *"does it open a PR"*: `prp-review` looks read-only but runs `gh pr checkout`, so it gets a worktree too.
+- **PR-producing work** → background agent, worktree-isolated: the agent creates its branch, commits, pushes, opens the PR.
+- **Store-only work** — reads files and writes to the PRP store (`prp-codebase-question`, `prp-debug`, `prp-plan`, `prp-prd`) → plain background agents, several in one message so they run concurrently.
 - Record each agent's ID/name and workstream row in the run file at launch. Respect `--max-parallel`: queue the rest, launch as slots free.
 
 Prompts must be self-sufficient (agents inherit nothing from this conversation) and must end with the escalation rule: *if blocked on a decision only a human can make, stop and report the blocker* — the orchestrator relays it to a gate and resumes the same agent via SendMessage with the answer, context intact.

--- a/plugins/prp-core/skills/prp-orchestrate/SKILL.md
+++ b/plugins/prp-core/skills/prp-orchestrate/SKILL.md
@@ -36,7 +36,7 @@ mkdir -p "$PRP_DIR"; [ -f "$PRP_DIR/project.json" ] || printf '{"path": "%s", "n
    - Issue → `prp-issue` (investigate, then fix)
    - Feature with an existing plan → `prp-implement` (+ `prp-pr`)
    - Feature from a description → `prp-loop`, or staged `prp-plan` → gate → `prp-implement` when the user should see plans before code
-   - Review-only / research-only → `prp-review` / `prp-codebase-question` (plain background agents, no worktree)
+   - Review-only → `prp-review` (worktree — it runs `gh pr checkout`); research-only → `prp-codebase-question` (plain background agent)
 3. Map dependencies and conflict risk: predict the files each workstream touches. Disjoint → parallel; overlapping → serialize or merge into one workstream.
 4. Size the batch. Default `--max-parallel 3`; raise only when workstreams are provably disjoint. More parallel agents = more merge surface and more gates.
 
@@ -61,8 +61,9 @@ Worktree agents branch from one tip while PRs diff against the other, and **both
 
 Launch each workstream as a **background agent** via the Agent/Task tool — see `references/launching.md` for the exact call shape and prompt template (read it before the first launch of a run):
 
-- **PR-producing work** → background agent with **worktree isolation**: the agent gets its own checkout, creates its branch, commits, pushes, opens the PR.
-- **Read-only work** (review, research, triage) → plain background agents, several in one message so they run concurrently.
+- **Worktree isolation is the default** — every workstream that touches the working tree gets its own checkout. The test is *"does it touch the working tree"*, not *"does it open a PR"*: `prp-review` looks read-only but runs `gh pr checkout`, so it gets a worktree too.
+- **PR-producing work** → background agent, worktree-isolated: the agent creates its branch, commits, pushes, opens the PR.
+- **Store-only work** — reads files and writes to the PRP store (`prp-codebase-question`, `prp-debug`, `prp-plan`, `prp-prd`) → plain background agents, several in one message so they run concurrently.
 - Record each agent's ID/name and workstream row in the run file at launch. Respect `--max-parallel`: queue the rest, launch as slots free.
 
 Prompts must be self-sufficient (agents inherit nothing from this conversation) and must end with the escalation rule: *if blocked on a decision only a human can make, stop and report the blocker* — the orchestrator relays it to a gate and resumes the same agent via SendMessage with the answer, context intact.


### PR DESCRIPTION
Follow-up to #35. That PR made `isolation: "worktree"` the default and used `prp-review` as the worked example of why *"does it open a PR"* is the wrong test — it runs `gh pr checkout`, so an unisolated review switches branches in the operator's checkout and moves their HEAD mid-session.

That change landed in `references/launching.md` and stopped there. `SKILL.md` kept the old rule and named `prp-review` explicitly as a plain background agent:

- `SKILL.md:39` — "Review-only / research-only → `prp-review` / `prp-codebase-question` (plain background agents, no worktree)"
- `SKILL.md:65` — "Read-only work (review, research, triage) → plain background agents"
- `launching.md:11` — "`prp-review` reads as read-only and is not… It gets a worktree."

The reference is read on demand; the body is always in context. So the wrong copy was the one loaded on every run, and the correction sat behind a lazy pointer — the failure mode `prp-meta-skill` warns about directly.

## Changes

- Phase 1's engine table routes `prp-review` to a worktree and leaves `prp-codebase-question` as a plain background agent.
- Phase 3 leads with isolation-as-default and the "does it touch the working tree" test, stated in the body rather than only in the reference.
- The exception is now the enumerable list (`prp-codebase-question`, `prp-debug`, `prp-plan`, `prp-prd`) instead of "read-only work (review, research, triage)" — that phrasing is what pulled `prp-review` to the wrong side.

Body 1,828 words. `python3 scripts/sync_plugin.py --check` passes; plugin and Codex renders included.